### PR TITLE
Fix traefik error handling in `ezs-python-server`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,3 +95,13 @@ majeur, un ajout de fonctionnalité ou une correction.
 
 Cela va créer un tag, modifier le numéro de version dans le README, et pousser
 le tout à la fois sur GitHub et sur Docker Hub.
+
+### Les images de base
+
+Le répertoire `bases` contient les images de base, c'est-à-dire celles qui
+simplifie l'écriture de plusieurs services web.
+
+Quand on met à jour les paquets npm de l'image racine `ezs-python-server`, il ne
+faut pas oublier de changer les versions des paquets du `package.json` situé à
+la racine du dépôt (pour que les serveurs lancés localement utilisent les mêmes
+versions que les serveurs sous Docker).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,3 +86,12 @@ Pour arrêter le serveur: Contrôle-C.
 
 Une fois que le nouveau service est créé, il faut l'ajouter à la liste du README
 de la racine du dépôt.
+
+### Création d'une version
+
+Se déplacer dans le répertoire du `Dockerfile` et lancer `npm version` en
+utilisant l'argument `major`, `minor` ou `patch` suivant qu'il y a un changement
+majeur, un ajout de fonctionnalité ou une correction.
+
+Cela va créer un tag, modifier le numéro de version dans le README, et pousser
+le tout à la fois sur GitHub et sur Docker Hub.

--- a/bases/ezs-python-server/Dockerfile
+++ b/bases/ezs-python-server/Dockerfile
@@ -12,7 +12,7 @@ RUN apt update && apt install -y tini && \
 USER pn
 WORKDIR /app/public
 RUN npm install dotenv-cli@7.3.0 && \
-    npm install @ezs/core@3.2.1 && \
+    npm install @ezs/core@3.2.2 && \
     npm install @ezs/analytics@2.2.1 && \
     npm install @ezs/basics@2.5.5 && \
     npm install @ezs/spawn@1.4.5

--- a/bases/ezs-python-server/README.md
+++ b/bases/ezs-python-server/README.md
@@ -5,3 +5,9 @@ Ce répertoire contient de quoi construire une image Docker lançant un serveur
 scripts python.
 
 C'est l'image de base des web services.
+
+## Versions utilisées
+
+| python | node   |
+| ------ | ------ |
+| 3.9.18 | 20.5.1 |

--- a/bases/ezs-python-server/README.md
+++ b/bases/ezs-python-server/README.md
@@ -1,4 +1,4 @@
-# ezs-python-server@1.0.0
+# ezs-python-server@1.0.1
 
 Ce répertoire contient de quoi construire une image Docker lançant un serveur
 [ezs](https://github.com/Inist-CNRS/ezs) ayant la possibilité de lancer des

--- a/bases/ezs-python-server/package.json
+++ b/bases/ezs-python-server/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ezs-python-server",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "ezs server + python",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ezs/analytics": "2.2.1",
     "@ezs/basics": "2.5.5",
-    "@ezs/core": "3.2.0",
+    "@ezs/core": "3.2.2",
     "@ezs/spawn": "1.4.5"
   }
 }

--- a/services/base-line-python/package.json
+++ b/services/base-line-python/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-base-line-python",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Base line web services in Python",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Last version of `@ezs/core` fixes error handling with traefik.