### PR TITLE
Update ezs/core to 3.3.0

### DIFF
--- a/bases/ezs-python-server/Dockerfile
+++ b/bases/ezs-python-server/Dockerfile
@@ -12,7 +12,7 @@ RUN apt update && apt install -y tini && \
 USER pn
 WORKDIR /app/public
 RUN npm install dotenv-cli@7.3.0 && \
-    npm install @ezs/core@3.2.2 && \
+    npm install @ezs/core@3.3.0 && \
     npm install @ezs/analytics@2.2.1 && \
     npm install @ezs/basics@2.5.5 && \
     npm install @ezs/spawn@1.4.5

--- a/bases/ezs-python-server/README.md
+++ b/bases/ezs-python-server/README.md
@@ -1,4 +1,4 @@
-# ezs-python-server@1.0.1
+# ezs-python-server@1.0.2
 
 Ce répertoire contient de quoi construire une image Docker lançant un serveur
 [ezs](https://github.com/Inist-CNRS/ezs) ayant la possibilité de lancer des

--- a/bases/ezs-python-server/package.json
+++ b/bases/ezs-python-server/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ezs-python-server",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "ezs server + python",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
   "dependencies": {
     "@ezs/analytics": "2.2.1",
     "@ezs/basics": "2.5.5",
-    "@ezs/core": "3.2.2",
+    "@ezs/core": "3.3.0",
     "@ezs/spawn": "1.4.5",
     "@orangeopensource/hurl": "4.1.0",
     "rest-cli": "1.8.13"
   },
   "devDependencies": {
-    "@types/node": "20.9.0"
+    "@types/node": "20.9.4"
   }
 }

--- a/services/base-line-python/Dockerfile
+++ b/services/base-line-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/ezs-python-server:py3.9-no20-1.0.1
+FROM cnrsinist/ezs-python-server:py3.9-no20-1.0.2
 
 USER pn
 WORKDIR /app/public

--- a/services/base-line-python/package.json
+++ b/services/base-line-python/package.json
@@ -17,7 +17,9 @@
     },
     "homepage": "https://github.com/Inist-CNRS/web-services/#readme",
     "scripts": {
-        "version:insert": "sed -i \"s#\\(${npm_package_name}.\\)\\([\\.a-z0-9]\\+\\)#\\1${npm_package_version}#g\" README.md && git add README.md",
+        "version:insert:readme": "sed -i \"s#\\(${npm_package_name}.\\)\\([\\.a-z0-9]\\+\\)#\\1${npm_package_version}#g\" README.md && git add README.md",
+        "version:insert:swagger": "sed -i \"s/\\\"version\\\": \\\"[0-9]\\+.[0-9]\\+.[0-9]\\+\\\"/\\\"version\\\": \\\"${npm_package_version}\\\"/g\" swagger.json && git add swagger.json",
+        "version:insert": "npm run version:insert:readme && npm run version:insert:swagger",
         "version:commit": "git commit -a -m \"release ${npm_package_name}@${npm_package_version}\"",
         "version:tag": "git tag \"${npm_package_name}@${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version}\"",
         "version:push": "git push && git push --tags",

--- a/services/base-line-python/package.json
+++ b/services/base-line-python/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-base-line-python",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Base line web services in Python",
     "repository": {
         "type": "git",

--- a/services/base-line-python/swagger.json
+++ b/services/base-line-python/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "base-line-python - Services en python dédiés aux tests",
 		"summary": "Vérifie la faisabilité de services en python",
-		"version": "0.0.0",
+		"version": "1.0.3",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/services/base-line/Dockerfile
+++ b/services/base-line/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/ezs-python-server:py3.9-no20-1.0.1
+FROM cnrsinist/ezs-python-server:py3.9-no20-1.0.2
 
 USER pn
 WORKDIR /app/public

--- a/services/base-line/package.json
+++ b/services/base-line/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-base-line",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Base line web services",
     "repository": {
         "type": "git",

--- a/services/base-line/package.json
+++ b/services/base-line/package.json
@@ -17,7 +17,9 @@
     },
     "homepage": "https://github.com/Inist-CNRS/web-services/#readme",
     "scripts": {
-        "version:insert": "sed -i \"s#\\(${npm_package_name}.\\)\\([\\.a-z0-9]\\+\\)#\\1${npm_package_version}#g\" README.md && git add README.md",
+        "version:insert:readme": "sed -i \"s#\\(${npm_package_name}.\\)\\([\\.a-z0-9]\\+\\)#\\1${npm_package_version}#g\" README.md && git add README.md",
+        "version:insert:swagger": "sed -i \"s/\\\"version\\\": \\\"[0-9]\\+.[0-9]\\+.[0-9]\\+\\\"/\\\"version\\\": \\\"${npm_package_version}\\\"/g\" swagger.json && git add swagger.json",
+        "version:insert": "npm run version:insert:readme && npm run version:insert:swagger",
         "version:commit": "git commit -a -m \"release ${npm_package_name}@${npm_package_version}\"",
         "version:tag": "git tag \"${npm_package_name}@${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version}\"",
         "version:push": "git push && git push --tags",

--- a/services/base-line/swagger.json
+++ b/services/base-line/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "base-line - Services dédiés aux tests",
 		"summary": "Propose plusieurs services ne proposant aucun traitement ce qui permet de vérfier ou mesurer les connexions ou les temps de réponse",
-		"version": "1.0.1",
+		"version": "1.0.2",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",


### PR DESCRIPTION
To be able to use [`[metrics]`](https://inist-cnrs.github.io/ezs/#/plugin-core?id=metrics) statement.

- [x] update `@ezs/core` to `3.3.0`
- [x] `npm version patch`
- [x] update `base-line` to use the last version of `ezs-python-server`
- [x] update `base-line-python` to use the last version of `ezs-python-server`