### PR TITLE
build: Target a non-protected branch

### DIFF
--- a/.github/workflows/docker-build-on-merge.yml
+++ b/.github/workflows/docker-build-on-merge.yml
@@ -36,6 +36,7 @@ jobs:
               shell: bash
               env:
                   GIT_REMOTE_REPO: 'https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}.git'
+                  GIT_REF: 'HEAD:${{ github.event.pull_request.head.ref }}'
 
               run: |
                   git config --global user.name "${{ github.actor }}"

--- a/services/base-line/package.json
+++ b/services/base-line/package.json
@@ -22,7 +22,7 @@
         "version:insert": "npm run version:insert:readme && npm run version:insert:swagger",
         "version:commit": "git commit -a -m \"release ${npm_package_name}@${npm_package_version}\"",
         "version:tag": "git tag \"${npm_package_name}@${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version}\"",
-        "version:push": "git push ${GIT_REMOTE_REPO} && git push --tags ${GIT_REMOTE_REPO}",
+        "version:push": "git push ${GIT_REMOTE_REPO} ${GIT_REF} && git push --tags ${GIT_REMOTE_REPO}",
         "version": "npm run version:insert && npm run version:commit && npm run version:tag",
         "postversion": "npm run version:push && npm run build && npm run publish",
         "build:dev": "docker build -t cnrsinist/${npm_package_name}:latest .",


### PR DESCRIPTION
At merge, the build-on-merge action failed, due to the protection of the main branch.
Let's try to push to the pull request's branch, hoping that it's still time.