### PR TITLE
Use node 16 instead of node 18

### DIFF
--- a/.github/workflows/docker-build-on-merge.yml
+++ b/.github/workflows/docker-build-on-merge.yml
@@ -31,6 +31,7 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: 20
+                  cache: 'npm'
 
             - name: Build & Push Docker Image
               shell: bash

--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -21,6 +21,7 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: 20
+                  cache: 'npm'
 
             - name: Install Hurl
               run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,12 +205,19 @@ de la racine du dépôt.
 ## Les images de base
 
 Le répertoire `bases` contient les images de base, c'est-à-dire celles qui
-simplifie l'écriture de plusieurs services web.
+simplifient l'écriture de plusieurs services web.
 
 Quand on met à jour les paquets npm de l'image racine `ezs-python-server`, il ne
 faut pas oublier de changer les versions des paquets du `package.json` situé à
 la racine du dépôt (pour que les serveurs lancés localement utilisent les mêmes
 versions que les serveurs sous Docker).
+
+Il y a plusieurs images de base:
+
+- [`python-node`](./bases/python-node/README.md): image avec python et node,
+  base des serveurs ezs
+- [`ezs-python-server`](./bases/ezs-python-server/README.md): serveur ezs vide,
+  acceptant les scripts ezs et python
 
 ## Nouvelle branche
 

--- a/bases/ezs-python-server/Dockerfile
+++ b/bases/ezs-python-server/Dockerfile
@@ -1,21 +1,27 @@
-FROM nikolaik/python-nodejs:python3.9-nodejs18-slim
+FROM cnrsinist/python-node:py3.9-no16-latest
 
-WORKDIR /app
-# See .dockerignore to see what files are copied
 RUN apt update && apt install -y tini && \
     echo '{ \
     "httpPort": 31976, \
     "configPath": "/app/config.json", \
     "dataPath": "/app/public" \
-    }' > /etc/ezmaster.json && \
-    chmod a+w /app
-USER pn
-WORKDIR /app/public
+    }' > /etc/ezmaster.json
+
+WORKDIR /app
 RUN npm install dotenv-cli@7.3.0 && \
     npm install @ezs/core@3.4.0 && \
     npm install @ezs/analytics@2.2.1 && \
     npm install @ezs/basics@2.5.5 && \
-    npm install @ezs/spawn@1.4.5
+    npm install @ezs/spawn@1.4.5 && \
+    chmod a+w /app
+
+# Make sure that .npm folder is readable by the daemon user
+WORKDIR /usr/sbin/.npm
+RUN chmod -R a+rwx /usr/sbin/.npm
+
+USER daemon
+WORKDIR /app/public
+# See .dockerignore to see what files are copied
 COPY . /app/
 
 ENTRYPOINT [ "/usr/bin/tini", "-g", "--" ]

--- a/bases/ezs-python-server/Dockerfile
+++ b/bases/ezs-python-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/python-node:py3.9-no16-latest
+FROM cnrsinist/python-node:py3.9-no16-1.0.0
 
 RUN apt update && apt install -y tini && \
     echo '{ \

--- a/bases/ezs-python-server/README.md
+++ b/bases/ezs-python-server/README.md
@@ -1,4 +1,4 @@
-# ezs-python-server@1.0.3
+# ezs-python-server@1.0.4
 
 Ce répertoire contient de quoi construire une image Docker lançant un serveur
 [ezs](https://github.com/Inist-CNRS/ezs) ayant la possibilité de lancer des

--- a/bases/ezs-python-server/README.md
+++ b/bases/ezs-python-server/README.md
@@ -8,6 +8,6 @@ C'est l'image de base des web services.
 
 ## Versions utilisées
 
-| python | node   |
-| ------ | ------ |
-| 3.9.18 | 20.5.1 |
+| python | node    |
+| ------ | ------- |
+| 3.9.18 | 16.20.2 |

--- a/bases/ezs-python-server/package.json
+++ b/bases/ezs-python-server/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ezs-python-server",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "ezs server + python",
     "repository": {
         "type": "git",

--- a/bases/python-node/Dockerfile
+++ b/bases/python-node/Dockerfile
@@ -1,0 +1,16 @@
+# Dockerfile
+FROM python:3.9-slim-bookworm
+
+ENV NODE_VERSION=16.20.2
+
+RUN apt update && apt install -y curl
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.6/install.sh | bash
+
+ENV NVM_DIR=/root/.nvm
+WORKDIR /root
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+RUN chmod -R a+rwx /root
+
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"

--- a/bases/python-node/Dockerfile
+++ b/bases/python-node/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM python:3.9-slim-bookworm
+FROM python:3.9.18-slim-bullseye
 
 ENV NODE_VERSION=16.20.2
 

--- a/bases/python-node/README.md
+++ b/bases/python-node/README.md
@@ -1,4 +1,4 @@
-# python-node@0.0.0
+# python-node@1.0.0
 
 Ce répertoire contient de quoi construire une image Docker avec python et node
 sous Debian.

--- a/bases/python-node/README.md
+++ b/bases/python-node/README.md
@@ -1,0 +1,12 @@
+# python-node@0.0.0
+
+Ce répertoire contient de quoi construire une image Docker avec python et node
+sous Debian.
+
+C'est l'image de base de [`ezs-python-server`](../ezs-python-server/README.md).
+
+## Versions utilisées
+
+| python | node    | système d'exploitation |
+| ------ | ------- | ---------------------- |
+| 3.9.18 | 16.20.2 | Debian bullseye        |

--- a/bases/python-node/package.json
+++ b/bases/python-node/package.json
@@ -1,14 +1,16 @@
 {
     "private": true,
-    "name": "ezs-python-server",
-    "version": "1.0.3",
-    "description": "ezs server + python",
+    "name": "python-node",
+    "version": "0.0.0",
+    "description": "python + node docker image",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/Inist-CNRS/web-services.git"
     },
     "keywords": [
-        "ezmaster"
+        "python",
+        "node",
+        "docker"
     ],
     "author": "François Parmentier <francois.parmentier@gmail.com>",
     "license": "MIT",

--- a/bases/python-node/package.json
+++ b/bases/python-node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "python-node",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "python + node docker image",
     "repository": {
         "type": "git",

--- a/services/base-line-python/Dockerfile
+++ b/services/base-line-python/Dockerfile
@@ -1,7 +1,9 @@
-FROM cnrsinist/ezs-python-server:py3.9-no20-1.0.2
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.4
 
-USER pn
-WORKDIR /app/public
+USER root
 RUN pip install unidecode==1.3.7
+
+USER daemon
+WORKDIR /app/public
 # Declare files to copy in .dockerignore
 COPY . /app/public/

--- a/services/base-line-python/README.md
+++ b/services/base-line-python/README.md
@@ -1,4 +1,4 @@
-# base-line-python@0.0.0
+# ws-base-line-python@0.0.0
 
 Services dédiés aux tests.
 

--- a/services/base-line-python/package.json
+++ b/services/base-line-python/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-base-line-python",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Base line web services in Python",
     "repository": {
         "type": "git",

--- a/services/base-line-python/swagger.json
+++ b/services/base-line-python/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "base-line-python - Services en python dédiés aux tests",
 		"summary": "Vérifie la faisabilité de services en python",
-		"version": "1.0.3",
+		"version": "1.0.4",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/services/base-line/Dockerfile
+++ b/services/base-line/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/ezs-python-server:py3.9-no16-latest
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.4
 
 # USER daemon
 WORKDIR /app/public

--- a/services/base-line/Dockerfile
+++ b/services/base-line/Dockerfile
@@ -1,6 +1,6 @@
-FROM cnrsinist/ezs-python-server:py3.9-no18-1.0.3
+FROM cnrsinist/ezs-python-server:py3.9-no16-latest
 
-USER pn
+# USER daemon
 WORKDIR /app/public
 # Declare files to copy in .dockerignore
 COPY . /app/public/

--- a/services/base-line/README.md
+++ b/services/base-line/README.md
@@ -1,4 +1,4 @@
-# base-line@1.0.1
+# base-line@1.0.3
 
 Services dédiés aux tests.
 

--- a/services/base-line/README.md
+++ b/services/base-line/README.md
@@ -1,4 +1,4 @@
-# base-line@1.0.3
+# ws-base-line@1.0.3
 
 Services dédiés aux tests.
 

--- a/services/base-line/package.json
+++ b/services/base-line/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-base-line",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "Base line web services",
     "repository": {
         "type": "git",

--- a/services/base-line/package.json
+++ b/services/base-line/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-base-line",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Base line web services",
     "repository": {
         "type": "git",

--- a/services/base-line/package.json
+++ b/services/base-line/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-base-line",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "Base line web services",
     "repository": {
         "type": "git",

--- a/services/base-line/package.json
+++ b/services/base-line/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-base-line",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Base line web services",
     "repository": {
         "type": "git",

--- a/services/base-line/swagger.json
+++ b/services/base-line/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "base-line - Services dédiés aux tests",
 		"summary": "Propose plusieurs services ne proposant aucun traitement ce qui permet de vérfier ou mesurer les connexions ou les temps de réponse",
-		"version": "1.0.3",
+		"version": "1.0.4",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/services/base-line/swagger.json
+++ b/services/base-line/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "base-line - Services dédiés aux tests",
 		"summary": "Propose plusieurs services ne proposant aucun traitement ce qui permet de vérfier ou mesurer les connexions ou les temps de réponse",
-		"version": "1.0.4",
+		"version": "1.0.5",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/services/base-line/swagger.json
+++ b/services/base-line/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "base-line - Services dédiés aux tests",
 		"summary": "Propose plusieurs services ne proposant aucun traitement ce qui permet de vérfier ou mesurer les connexions ou les temps de réponse",
-		"version": "1.0.5",
+		"version": "1.0.6",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/services/base-line/swagger.json
+++ b/services/base-line/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "base-line - Services dédiés aux tests",
 		"summary": "Propose plusieurs services ne proposant aucun traitement ce qui permet de vérfier ou mesurer les connexions ou les temps de réponse",
-		"version": "1.0.2",
+		"version": "1.0.3",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/services/base-line/v1/no-accent.ini
+++ b/services/base-line/v1/no-accent.ini
@@ -2,8 +2,8 @@
 mimeType = application/json
 
 post.operationId = post-v1-no-accent
-post.description = Exemple d'utilisatino d'une fonction adhoc
-post.summary = Récupération à partir d'un tableau d'objets avec à minima un champ value contenant une chaine de caractère
+post.description = Exemple d'utilisation d'une fonction adhoc
+post.summary = Récupération à partir d'un tableau d'objets avec à minima un champ value contenant une chaîne de caractères
 post.tags.0 = base-line
 post.requestBody.content.application/json.example.0.id = 1
 post.requestBody.content.application/json.example.0.value = école

--- a/services/base-line/v1/no-accent2.ini
+++ b/services/base-line/v1/no-accent2.ini
@@ -2,8 +2,8 @@
 mimeType = application/json
 
 post.operationId = post-v1-no-accent2
-post.description = Exemple d'utilisatino d'une fonction adhoc
-post.summary = Récupération à partir d'un tableau d'objets avec à minima un champ value contenant une chaine de caractère
+post.description = Exemple d'utilisation d'une fonction adhoc
+post.summary = Récupération à partir d'un tableau d'objets avec à minima un champ value contenant une chaîne de caractères
 post.tags.0 = base-line
 post.requestBody.content.application/json.example.0.id = 1
 post.requestBody.content.application/json.example.0.value = école


### PR DESCRIPTION
Create a python-node docker image, because node 16 is no more available, and node 18 does not work on old docker versions.

User `daemon` launches the ezs server, because that's the user which ezmaster-webdav uses.