### PR TITLE
fix(python-node): Cache happen to be created in /root/.npm

### DIFF
--- a/bases/ezs-python-saxon-server/Dockerfile
+++ b/bases/ezs-python-saxon-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.6
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.7
 
 ARG saxon_ver=10.9
 ENV SAXON_HOME=/usr/share/java/saxon

--- a/bases/ezs-python-saxon-server/README.md
+++ b/bases/ezs-python-saxon-server/README.md
@@ -1,4 +1,4 @@
-# ezs-python-saxon-server@1.0.0
+# ezs-python-saxon-server@1.0.1
 
 Ce répertoire contient de quoi construire une image Docker lançant un serveur
 [ezs](https://github.com/Inist-CNRS/ezs) ayant la possibilité de lancer des

--- a/bases/ezs-python-saxon-server/package.json
+++ b/bases/ezs-python-saxon-server/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ezs-python-saxon-server",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "ezs server + python + saxon",
     "repository": {
         "type": "git",

--- a/bases/ezs-python-server/Dockerfile
+++ b/bases/ezs-python-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/python-node:py3.9-no16-1.0.0
+FROM cnrsinist/python-node:py3.9-no16-1.0.1
 
 RUN apt update && apt install -y tini && \
     echo '{ \

--- a/bases/ezs-python-server/README.md
+++ b/bases/ezs-python-server/README.md
@@ -1,4 +1,4 @@
-# ezs-python-server@1.0.6
+# ezs-python-server@1.0.7
 
 Ce répertoire contient de quoi construire une image Docker lançant un serveur
 [ezs](https://github.com/Inist-CNRS/ezs) ayant la possibilité de lancer des

--- a/bases/ezs-python-server/package.json
+++ b/bases/ezs-python-server/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ezs-python-server",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "description": "ezs server + python",
     "repository": {
         "type": "git",

--- a/bases/python-node/Dockerfile
+++ b/bases/python-node/Dockerfile
@@ -12,5 +12,6 @@ RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 RUN chmod -R a+rwx /root
+RUN chown -R 1:1 "/root/.npm"
 
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"

--- a/bases/python-node/README.md
+++ b/bases/python-node/README.md
@@ -1,4 +1,4 @@
-# python-node@1.0.0
+# python-node@1.0.1
 
 Ce répertoire contient de quoi construire une image Docker avec python et node
 sous Debian.

--- a/bases/python-node/package.json
+++ b/bases/python-node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "python-node",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "python + node docker image",
     "repository": {
         "type": "git",

--- a/services/base-line-python/Dockerfile
+++ b/services/base-line-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.6
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.7
 
 USER root
 RUN pip install unidecode==1.3.7

--- a/services/base-line-python/README.md
+++ b/services/base-line-python/README.md
@@ -1,4 +1,4 @@
-# ws-base-line-python@1.0.6
+# ws-base-line-python@1.0.7
 
 Services dédiés aux tests.
 

--- a/services/base-line-python/package.json
+++ b/services/base-line-python/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-base-line-python",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "description": "Base line web services in Python",
     "repository": {
         "type": "git",

--- a/services/base-line-python/swagger.json
+++ b/services/base-line-python/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "base-line-python - Services en python dédiés aux tests",
 		"summary": "Vérifie la faisabilité de services en python",
-		"version": "1.0.6",
+		"version": "1.0.7",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/services/base-line/Dockerfile
+++ b/services/base-line/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.6
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.7
 
 # USER daemon
 WORKDIR /app/public

--- a/services/base-line/README.md
+++ b/services/base-line/README.md
@@ -1,4 +1,4 @@
-# ws-base-line@1.0.8
+# ws-base-line@1.0.9
 
 Services dédiés aux tests.
 

--- a/services/base-line/package.json
+++ b/services/base-line/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-base-line",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "description": "Base line web services",
     "repository": {
         "type": "git",

--- a/services/base-line/swagger.json
+++ b/services/base-line/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "base-line - Services dédiés aux tests",
 		"summary": "Propose plusieurs services ne proposant aucun traitement ce qui permet de vérfier ou mesurer les connexions ou les temps de réponse",
-		"version": "1.0.8",
+		"version": "1.0.9",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/services/terms-extraction/Dockerfile
+++ b/services/terms-extraction/Dockerfile
@@ -1,16 +1,12 @@
-FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.6
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.7
 
 USER root
-# Install all python dependencies
-# RUN pip install \
-#     unidecode==1.3.7
 
 # Install all node dependencies
 RUN npm install \
     @ezs/teeft@2.3.1 \
     @ezs/strings@1.0.3
 
-# USER daemon
 WORKDIR /app/public
 # Declare files to copy in .dockerignore
 COPY --chown=daemon:daemon . /app/public/

--- a/services/terms-extraction/README.md
+++ b/services/terms-extraction/README.md
@@ -1,4 +1,4 @@
-# ws-terms-extraction@1.0.0
+# ws-terms-extraction@1.5.1
 
 Extraction de termes
 

--- a/services/terms-extraction/README.md
+++ b/services/terms-extraction/README.md
@@ -1,4 +1,4 @@
-# ws-terms-extraction@1.5.1
+# ws-terms-extraction@1.5.2
 
 Extraction de termes
 

--- a/services/terms-extraction/package.json
+++ b/services/terms-extraction/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-terms-extraction",
-    "version": "1.0.0",
+    "version": "1.5.1",
     "description": "Extraction de termes",
     "repository": {
         "type": "git",

--- a/services/terms-extraction/package.json
+++ b/services/terms-extraction/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-terms-extraction",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "Extraction de termes",
     "repository": {
         "type": "git",

--- a/services/terms-extraction/swagger.json
+++ b/services/terms-extraction/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "terms-extraction - Extraction de termes",
 		"summary": "Extraction de termes à partir de textes en anglais ou en français.",
-		"version": "1.0.0",
+		"version": "1.5.1",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/services/terms-extraction/swagger.json
+++ b/services/terms-extraction/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "terms-extraction - Extraction de termes",
 		"summary": "Extraction de termes à partir de textes en anglais ou en français.",
-		"version": "1.5.1",
+		"version": "1.5.2",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.6
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.7
 
 USER root
 # Install all python dependencies


### PR DESCRIPTION
When running `ws-terms-extraction@1.0.0`, the root page of the server return a 404, and the logs contained:

```log
npm ERR! code EACCES
npm ERR! syscall open
npm ERR! path /root/.npm/_cacache/tmp/1b088e67
npm ERR! errno -13
npm ERR! 
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR! 
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 1:1 "/root/.npm"

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2024-01-19T07_54_39_306Z-debug-0.log
npm notice 
npm notice New major version of npm available! 8.19.4 -> 10.3.0
npm notice Changelog: https://github.com/npm/cli/releases/tag/v10.3.0
npm notice Run npm install -g npm@10.3.0 to update!
npm notice 
```