### PR TITLE
Add a script to facilitate the upgrade of images depending on a base image

### DIFF
--- a/bin/dry-run.sh
+++ b/bin/dry-run.sh
@@ -1,0 +1,3 @@
+function run() {
+    printf "%s\n" "$*"
+}

--- a/bin/update-images.sh
+++ b/bin/update-images.sh
@@ -1,25 +1,30 @@
 #!/usr/bin/env bash
 
-# $1 should be in `ezs-python-server`, or `ezs-python-saxon-server` format
-# But `bases/ezs-python-server` is accepted too.
-CHANGING_BASE=${1/bases\//}
-CHANGING_BASE=${CHANGING_BASE%/}
+function updateImage() {
+    # $1 should be in `ezs-python-server`, or `ezs-python-saxon-server` format
+    # But `bases/ezs-python-server` is accepted too.
+    CHANGING_BASE=${1/bases\//}
+    CHANGING_BASE=${CHANGING_BASE%/}
 
-printf "Update images depending from %s\n\n" "$CHANGING_BASE"
+    printf "Update images depending from %s\n\n" "$CHANGING_BASE"
 
-BASE_IMAGE_VERSION=$(node -e "console.log(require('./bases/$CHANGING_BASE/package.json').version)")
-BASE_IMAGE_TAG_BEGINNING=$(node -e "console.log(require('./bases/$CHANGING_BASE/package.json').scripts.build.split(':')[1].split('{')[0].slice(0,-2))")
-BASE_IMAGE_TAG="$BASE_IMAGE_TAG_BEGINNING-$BASE_IMAGE_VERSION"
-printf "Tag of the image: %s\n\n" "$BASE_IMAGE_TAG"
+    BASE_IMAGE_VERSION=$(node -e "console.log(require('./bases/$CHANGING_BASE/package.json').version)")
+    BASE_IMAGE_TAG_BEGINNING=$(node -e "console.log(require('./bases/$CHANGING_BASE/package.json').scripts.build.split(':')[1].split('{')[0].slice(0,-2))")
+    BASE_IMAGE_TAG="$BASE_IMAGE_TAG_BEGINNING-$BASE_IMAGE_VERSION"
+    printf "Tag of the image: %s\n\n" "$BASE_IMAGE_TAG"
 
-DOCKERFILES=$(ls bases/*/Dockerfile template/Dockerfile services/*/Dockerfile)
+    DOCKERFILES=$(ls bases/*/Dockerfile template/Dockerfile services/*/Dockerfile)
 
 
-printf "Directly depending images:\n"
+    printf "Directly depending images:\n"
 
-DEPENDING_DOCKERFILES=$(grep -i "^FROM cnrsinist/$CHANGING_BASE:$BASE_IMAGE_TAG" $DOCKERFILES | sed -e 's/:.*$//')
+    DEPENDING_DOCKERFILES=$(grep -i "^FROM cnrsinist/$CHANGING_BASE:$BASE_IMAGE_TAG" $DOCKERFILES | sed -e 's/:.*$//')
 
-for DOCKERFILE in $DEPENDING_DOCKERFILES
-do
-    printf " - %s\n" "$DOCKERFILE"
-done
+    for DOCKERFILE in $DEPENDING_DOCKERFILES
+    do
+        printf " - %s\n" "$DOCKERFILE"
+    done
+
+}
+
+updateImage "$1"

--- a/bin/update-images.sh
+++ b/bin/update-images.sh
@@ -1,12 +1,28 @@
 #!/usr/bin/env bash
 
-function updateImage() {
+function dryRun() {
+    printf "%s\n" "$*"
+}
+
+# This function updates the Docker images for a specified base.
+# It parses the base name, extracts the version from its package.json, and
+# constructs the beginning of the image tag.
+#
+# @param {string} base image name in the format `ezs-python-server` or
+#                 `basees/ezs-python-saxon-server`
+# @param {number} [level=0] level of the recursion
+function updateBase() {
     # $1 should be in `ezs-python-server`, or `ezs-python-saxon-server` format
     # But `bases/ezs-python-server` is accepted too.
     CHANGING_BASE=${1/bases\//}
     CHANGING_BASE=${CHANGING_BASE%/}
 
-    printf "Update images depending from %s\n\n" "$CHANGING_BASE"
+    LEVEL=${2:-0}
+    if [ "$LEVEL" -ge 1 ]; then
+        printf "\n"
+    fi
+
+    printf "Update images depending from %s (level %s)\n\n" "$CHANGING_BASE" "$LEVEL"
 
     BASE_IMAGE_VERSION=$(node -e "console.log(require('./bases/$CHANGING_BASE/package.json').version)")
     BASE_IMAGE_TAG_BEGINNING=$(node -e "console.log(require('./bases/$CHANGING_BASE/package.json').scripts.build.split(':')[1].split('{')[0].slice(0,-2))")
@@ -25,6 +41,22 @@ function updateImage() {
         printf " - %s\n" "$DOCKERFILE"
     done
 
+    printf "\nUpdating images:\n\n"
+
+    for DOCKERFILE in $DEPENDING_DOCKERFILES
+    do
+        printf " - %s\n" "$DOCKERFILE"
+        sed -i -e "s/cnrsinist\/$CHANGING_BASE:.*$/cnrsinist\/$CHANGING_BASE:$BASE_IMAGE_TAG/g" "$DOCKERFILE"
+        IMAGE_DIR=$(dirname "$DOCKERFILE")
+        dryRun npm -w "$IMAGE_DIR" version patch
+        TYPE=$(dirname "$IMAGE_DIR")
+        if [ "$TYPE" = "bases" ]; then
+            dryRun npm -w "$IMAGE_DIR" run build
+            dryRun npm -w "$IMAGE_DIR" run publish
+            updateBase "$IMAGE_DIR" $((LEVEL+1))
+        fi
+        printf "\n"
+    done
 }
 
-updateImage "$1"
+updateBase "$1"

--- a/bin/update-images.sh
+++ b/bin/update-images.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# $1 should be in `ezs-python-server`, or `ezs-python-saxon-server` format
+# But `bases/ezs-python-server` is accepted too.
+CHANGING_BASE=${1/bases\//}
+CHANGING_BASE=${CHANGING_BASE%/}
+
+printf "Update images depending from %s\n\n" "$CHANGING_BASE"
+
+BASE_IMAGE_VERSION=$(node -e "console.log(require('./bases/$CHANGING_BASE/package.json').version)")
+BASE_IMAGE_TAG_BEGINNING=$(node -e "console.log(require('./bases/$CHANGING_BASE/package.json').scripts.build.split(':')[1].split('{')[0].slice(0,-2))")
+BASE_IMAGE_TAG="$BASE_IMAGE_TAG_BEGINNING-$BASE_IMAGE_VERSION"
+printf "Tag of the image: %s\n\n" "$BASE_IMAGE_TAG"
+
+DOCKERFILES=$(ls bases/*/Dockerfile template/Dockerfile services/*/Dockerfile)
+
+
+printf "Directly depending images:\n"
+
+DEPENDING_DOCKERFILES=$(grep -i "^FROM cnrsinist/$CHANGING_BASE:$BASE_IMAGE_TAG" $DOCKERFILES | sed -e 's/:.*$//')
+
+for DOCKERFILE in $DEPENDING_DOCKERFILES
+do
+    printf " - %s\n" "$DOCKERFILE"
+done

--- a/bin/update-images.sh
+++ b/bin/update-images.sh
@@ -1,8 +1,38 @@
 #!/usr/bin/env bash
 
-function dryRun() {
-    printf "%s\n" "$*"
+function usage() {
+    printf "Usage: ./bin/update-images.sh [--help | [--dry-run] <service-name>]\n"
 }
+
+DRY=false
+TO_UPDATE=""
+
+for arg in "$@"; do
+    case $arg in
+        --dry-run)
+            DRY=true
+            shift # Remove --dry-run from processing
+            ;;
+        --help)
+            usage
+            exit 1
+            ;;
+        *)
+            TO_UPDATE="$arg"
+            ;;
+    esac
+done
+
+if [ -z "$TO_UPDATE" ]; then
+    usage
+    exit 1
+fi
+
+if [ "$DRY" = true ]; then
+    . bin/dry-run.sh
+else
+    . bin/wet-run.sh
+fi
 
 # This function updates the Docker images for a specified base.
 # It parses the base name, extracts the version from its package.json, and
@@ -40,23 +70,23 @@ function updateBase() {
     for DOCKERFILE in $DEPENDING_DOCKERFILES
     do
         printf " - %s\n" "$DOCKERFILE"
-        dryRun sed -i -e "s/cnrsinist\/$CHANGING_BASE:.*$/cnrsinist\/$CHANGING_BASE:$BASE_IMAGE_TAG/g" "$DOCKERFILE"
+        run "sed -i -e \"s/cnrsinist\/$CHANGING_BASE:.*$/cnrsinist\/$CHANGING_BASE:$BASE_IMAGE_TAG/g\" \"$DOCKERFILE\""
         IMAGE_DIR=$(dirname "$DOCKERFILE")
         TYPE=$(dirname "$IMAGE_DIR")
         if [ "$IMAGE_DIR" = "template" ]; then
-            dryRun git add template
-            dryRun git commit -m "Update template to $CHANGING_BASE:$BASE_IMAGE_TAG"
-            dryRun git push
+            run git add template
+            run "git commit -m \"Update template to $CHANGING_BASE:$BASE_IMAGE_TAG\""
+            run git push
         else
-            dryRun npm -w "$IMAGE_DIR" version patch
+            run "npm -w \"$IMAGE_DIR\" version patch"
         fi
         if [ "$TYPE" = "bases" ]; then
-            dryRun npm -w "$IMAGE_DIR" run build
-            dryRun npm -w "$IMAGE_DIR" run publish
+            run "npm -w \"$IMAGE_DIR\" run build"
+            run "npm -w \"$IMAGE_DIR\" run publish"
             printf "\n***** Don't forget to run \"%s\" *******\n" "updateBase $IMAGE_DIR"
         fi
         printf "\n"
     done
 }
 
-updateBase "$1"
+updateBase "$TO_UPDATE"

--- a/bin/update-images.sh
+++ b/bin/update-images.sh
@@ -45,7 +45,7 @@ function updateBase() {
         TYPE=$(dirname "$IMAGE_DIR")
         if [ "$IMAGE_DIR" = "template" ]; then
             dryRun git add template
-            dryRun git commit -m "Update template"
+            dryRun git commit -m "Update template to $CHANGING_BASE:$BASE_IMAGE_TAG"
             dryRun git push
         else
             dryRun npm -w "$IMAGE_DIR" version patch

--- a/bin/update-images.sh
+++ b/bin/update-images.sh
@@ -10,17 +10,11 @@ function dryRun() {
 #
 # @param {string} base image name in the format `ezs-python-server` or
 #                 `basees/ezs-python-saxon-server`
-# @param {number} [level=0] level of the recursion
 function updateBase() {
     # $1 should be in `ezs-python-server`, or `ezs-python-saxon-server` format
     # But `bases/ezs-python-server` is accepted too.
     CHANGING_BASE=${1/bases\//}
     CHANGING_BASE=${CHANGING_BASE%/}
-
-    LEVEL=${2:-0}
-    if [ "$LEVEL" -ge 1 ]; then
-        printf "\n"
-    fi
 
     printf "Update images depending from %s (level %s)\n\n" "$CHANGING_BASE" "$LEVEL"
 
@@ -46,14 +40,20 @@ function updateBase() {
     for DOCKERFILE in $DEPENDING_DOCKERFILES
     do
         printf " - %s\n" "$DOCKERFILE"
-        sed -i -e "s/cnrsinist\/$CHANGING_BASE:.*$/cnrsinist\/$CHANGING_BASE:$BASE_IMAGE_TAG/g" "$DOCKERFILE"
+        dryRun sed -i -e "s/cnrsinist\/$CHANGING_BASE:.*$/cnrsinist\/$CHANGING_BASE:$BASE_IMAGE_TAG/g" "$DOCKERFILE"
         IMAGE_DIR=$(dirname "$DOCKERFILE")
-        dryRun npm -w "$IMAGE_DIR" version patch
         TYPE=$(dirname "$IMAGE_DIR")
+        if [ "$IMAGE_DIR" = "template" ]; then
+            dryRun git add template
+            dryRun git commit -m "Update template"
+            dryRun git push
+        else
+            dryRun npm -w "$IMAGE_DIR" version patch
+        fi
         if [ "$TYPE" = "bases" ]; then
             dryRun npm -w "$IMAGE_DIR" run build
             dryRun npm -w "$IMAGE_DIR" run publish
-            updateBase "$IMAGE_DIR" $((LEVEL+1))
+            printf "\n***** Don't forget to run \"%s\" *******\n" "updateBase $IMAGE_DIR"
         fi
         printf "\n"
     done

--- a/bin/wet-run.sh
+++ b/bin/wet-run.sh
@@ -1,0 +1,3 @@
+function run() {
+    exec "$*"
+}


### PR DESCRIPTION
Because when `ezs` packages are updated, the `ezs-python-server` has to be updated, and then many other depending services, the template, ...