### PR TITLE
chore(terms-extraction): Set production url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -413,3 +413,57 @@ automatiquement l'image sur Docker Hub.
 > **Remarque**: on peut aussi utiliser l'option *workspace* `-w` de npm pour
 > créer la version depuis la racine du dépôt: `npm version -w
 > services/service-name patch`.
+
+## Mise en production
+
+Pour la mise en production d'un service, il faut modifier son fichier
+`swagger.json`.  
+
+Il faut transformer cette partie:
+
+```json
+    "servers": [
+        {
+            "x-comment": "Will be automatically completed by the ezs server."
+        },
+        {
+            "url": "http://vptdmservices.intra.inist.fr:49233/",
+            "description": "Latest version for production",
+            "#DISABLED#x-profil": "Standard"
+        }
+    ],
+```
+
+en
+
+```json
+    "servers": [
+        {
+            "x-comment": "Will be automatically completed by the ezs server."
+        },
+        {
+            "url": "http://vptdmservices.intra.inist.fr:49245/",
+            "description": "Latest version for production",
+            "x-profil": "Standard"
+        }
+    ],
+```
+
+Où:
+
+1. on enlève `#DISABLED#` devant `x-profil`, en vérifiant que la valeur de ce
+   champ est bien `Standard`,
+2. on ajuste le champ `url` du même objet pour pointer sur l'URL interne du
+   container sur la machine de production.
+
+> ⚠ Pendant la phase de transition du code source des services web, on publiera
+> les services en production à partir du dépôt
+> [GitBucket](https://gitbucket.inist.fr/tdm/web-services) où la procédure est
+> la même, mais où on supprimera tous les fichiers du services, excepté
+> `swagger.json`, qui contiendra les mêmes valeurs que sur GitHub.
+
+Puis, on lance `./bin/publish`, qui demande les *login* et mot de passe de la
+machine du *reverse proxy*.
+
+> Le script `./bin/publish` à utiliser pendant la phase de transition est celui
+> du GitBucket.

--- a/services/terms-extraction/swagger.json
+++ b/services/terms-extraction/swagger.json
@@ -1,33 +1,33 @@
 {
-	"openapi": "3.0.0",
-	"info": {
-		"title": "terms-extraction - Extraction de termes",
-		"summary": "Extraction de termes à partir de textes en anglais ou en français.",
-		"version": "1.5.2",
-		"termsOfService": "https://services.istex.fr/",
-		"contact": {
-			"name": "Inist-CNRS",
-			"url": "https://www.inist.fr/nous-contacter/"
-		}
-	},
-	"servers": [
-		{
-			"x-comment": "Will be automatically completed by the ezs server."
-		},
-		{
-			"url": "http://vptdmservices.intra.inist.fr:49225/",
-			"description": "Latest version for production",
-			"#DISABLED#x-profil": "Standard"
-		}
-	],
-	"tags": [
-		{
-			"name": "terms-extraction",
-			"description": "Extraction de termes",
-			"externalDocs": {
-				"description": "Plus de documentation",
-				"url": "https://github.com/inist-cnrs/web-services/tree/main/services/terms-extraction"
-			}
-		}
-	]
+    "openapi": "3.0.0",
+    "info": {
+        "title": "terms-extraction - Extraction de termes",
+        "summary": "Extraction de termes à partir de textes en anglais ou en français.",
+        "version": "1.5.2",
+        "termsOfService": "https://services.istex.fr/",
+        "contact": {
+            "name": "Inist-CNRS",
+            "url": "https://www.inist.fr/nous-contacter/"
+        }
+    },
+    "servers": [
+        {
+            "x-comment": "Will be automatically completed by the ezs server."
+        },
+        {
+            "url": "http://vptdmservices.intra.inist.fr:49245/",
+            "description": "Latest version for production",
+            "x-profil": "Standard"
+        }
+    ],
+    "tags": [
+        {
+            "name": "terms-extraction",
+            "description": "Extraction de termes",
+            "externalDocs": {
+                "description": "Plus de documentation",
+                "url": "https://github.com/inist-cnrs/web-services/tree/main/services/terms-extraction"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
During transition phase: set the correct url in `swagger.json`, enable `x-profil` and set it to `Standard` to indicate that the URL is the internal one in production.