### PR TITLE
feat(biblio-ref): update output of service

### DIFF
--- a/services/biblio-ref/examples.http
+++ b/services/biblio-ref/examples.http
@@ -12,7 +12,19 @@ POST {{host}}/v1/validate?indent=true HTTP/1.1
 Content-Type: application/json
 
 [
-	{ "value": "Zohuri, B. (2019). A Comparison of Molten Salt Reactors to Light Water Reactors: Pros and Cons. In Molten Salt Reactors and Thorium Energy (pp. 81-98). Woodhead Publishing. https://doi.org/10.1016/B978-0-08-102337-2.00006-9" },
-	{ "value": "RETRACTED > Gerris Caucasicus, Primary Prevention of Cardiovascular Disease with a Mediterranean Diet, 10.1056/nejmoa1200303" },
-	{ "value": "please see 10.1371/journal.pgen.1001111" }
+  {
+    "value": "Zohuri, B. (2019). A Comparison of Molten Salt Reactors to Light Water Reactors: Pros and Cons. In Molten Salt Reactors and Thorium Energy (pp. 81-98). Woodhead Publishing. https://doi.org/10.1016/B978-0-08-102337-2.00006-9"
+  },
+  {
+    "value": "Please see https://doi.org/10.1016\/b978-0-323-90638-8.00002-3"
+  },
+  {
+    "value": "Gerris Caucasicus, Primary Prevention of Cardiovascular Disease with a Mediterranean Diet, 10.1056/nejmoa1200303"
+  },
+  {
+    "value": ["bad","input","type"]
+  },
+  {
+    "value": "nothing here"
+  }
 ]

--- a/services/biblio-ref/tests.hurl
+++ b/services/biblio-ref/tests.hurl
@@ -1,28 +1,51 @@
 POST {{host}}/v1/validate?indent=true
 content-type: application/json
 [
-	{ "value": "Zohuri, B. (2019). A Comparison of Molten Salt Reactors to Light Water Reactors: Pros and Cons. In Molten Salt Reactors and Thorium Energy (pp. 81-98). Woodhead Publishing. https://doi.org/10.1016/B978-0-08-102337-2.00006-9" },
-	{ "value": "RETRACTED > Gerris Caucasicus, Primary Prevention of Cardiovascular Disease with a Mediterranean Diet, 10.1056/nejmoa1200303" },
-	{ "value": "please see 10.1371/journal.pgen.1001111" }
+  {
+    "value": "Zohuri, B. (2019). A Comparison of Molten Salt Reactors to Light Water Reactors: Pros and Cons. In Molten Salt Reactors and Thorium Energy (pp. 81-98). Woodhead Publishing. https://doi.org/10.1016/B978-0-08-102337-2.00006-9"
+  },
+  {
+    "value": "Please see https://doi.org/10.1016\/b978-0-323-90638-8.00002-3"
+  },
+  {
+    "value": "Gerris Caucasicus, Primary Prevention of Cardiovascular Disease with a Mediterranean Diet, 10.1056/nejmoa1200303"
+  },
+  {
+    "value": ["bad","input","type"]
+  },
+  {
+    "value": "nothing here"
+  }
 ]
-
 
 HTTP 200
 [{
     "value": {
-        "is_found": false,
-        "is retracted": false
+        "doi": "",
+        "status": "not_found"
     }
 },
 {
     "value": {
-        "is_found": true,
-        "is retracted": true
+        "doi": "10.1016/b978-0-323-90638-8.00002-3",
+        "status": "found"
     }
 },
 {
     "value": {
-        "is_found": true,
-        "is retracted": false
+        "doi": "10.1056/nejmoa1200303",
+        "status": "retracted"
+    }
+},
+{
+    "value": {
+        "doi": "",
+        "status": "error_data"
+    }
+},
+{
+    "value": {
+        "doi": "",
+        "status": "not_found"
     }
 }]

--- a/services/biblio-ref/v1/validate.py
+++ b/services/biblio-ref/v1/validate.py
@@ -59,7 +59,8 @@ for line in sys.stdin:
 
     doi = find_doi(ref_biblio)
     if doi:  # doi is True if and only if a doi is found with the regex doi_regex
-        if verify_doi(doi)==200:  # If request return code 200
+        crossref_status_code = verify_doi(doi) # Verify doi using crossref api
+        if crossref_status_code==200:  # If request return code 200
             status = "found"
             if doi in retracted_doi:
                 status = "retracted"
@@ -67,7 +68,7 @@ for line in sys.stdin:
             json.dump(data, sys.stdout)
             sys.stdout.write("\n")
             
-        elif verify_doi(doi)==404:  # If request return code 404
+        elif crossref_status_code==404:  # If request return code 404
             data["value"] = {"doi":"","status": "not_found"}
             json.dump(data, sys.stdout)
             sys.stdout.write("\n")

--- a/services/biblio-ref/v1/validate.py
+++ b/services/biblio-ref/v1/validate.py
@@ -31,47 +31,57 @@ def find_doi(text):
 
 def verify_doi(doi, mail=mail_adress):
     """
-    check with crossref api if doi is correct.
-    Do not use this function without function "find_doi"
+    Check with crossref API if DOI is correct.
+    Do not use this function without function "find_doi".
+    
+    Returns HTTP code
     """
     url = f"https://api.crossref.org/works/{doi}/agency?mailto={mail}"
 
-    # Return True if DOI exists in crossref api AND if request worked
     try:
-        code_response = session.get(url).status_code
-        return code_response == 200
-    except:
-        return False
+        response = session.get(url)
+        return response.status_code
+
+    except Exception:
+        return 503 # if there is an unexpected error from crossref
 
 
 for line in sys.stdin:
     data = json.loads(line)
     ref_biblio = data["value"]
-    is_found = False
-    is_retracted = False
 
     # check if "value" is a string
     if not isinstance(ref_biblio, str):
-        data["value"] = {"is_found": is_found, "is retracted": is_retracted}
+        data["value"] = {"doi":"","status": "error_data"}
         json.dump(data, sys.stdout)
         sys.stdout.write("\n")
         continue
 
     doi = find_doi(ref_biblio)
     if doi:  # doi is True if and only if a doi is found with the regex doi_regex
-        if verify_doi(doi):  # If request return code 200
-            is_found = True
+        if verify_doi(doi)==200:  # If request return code 200
+            status = "found"
             if doi in retracted_doi:
-                is_retracted = True
+                status = "retracted"
+            data["value"] = {"doi":doi,"status": status}
+            json.dump(data, sys.stdout)
+            sys.stdout.write("\n")
+            
+        elif verify_doi(doi)==404:  # If request return code 404
+            data["value"] = {"doi":"","status": "not_found"}
+            json.dump(data, sys.stdout)
+            sys.stdout.write("\n")
+            
+        else:
+            data["value"] = {"doi":"","status": "error_service"}
+            json.dump(data, sys.stdout)
+            sys.stdout.write("\n")
 
-        data["value"] = {"is_found": is_found, "is retracted": is_retracted}
-        json.dump(data, sys.stdout)
-        sys.stdout.write("\n")
 
     else:
         # C'est dans cette partie que l'on traitera la partie 2 du WS
         # data["value"] = future_function_to_check(ref_biblio)
 
-        data["value"] = {"is_found": is_found, "is retracted": is_retracted}
+        data["value"] = {"doi":"","status": "not_found"}
         json.dump(data, sys.stdout)
         sys.stdout.write("\n")


### PR DESCRIPTION
now service return the doi if found AND a single key "status" (instead of retracted + found) but the value's type is no more boolean.
Example of output :
- "error_data" (data not string),
-  "found",
-  "not_found" (no doi or doi doesn't match) ,
-  "error_service" (when response from crossref api isn't a 200 or 404)