### PR TITLE
Update bases/ezs-python-server to ezs/core 3.6.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -402,6 +402,11 @@ Il y a plusieurs images de base:
   serveur ezs vide, acceptant les scripts ezs et python, embarquant saxon, sous
   la forme de la commande `xslt`.
 
+> **Note:** il existe maintenant un script qui se charge de la mise à jour des
+> images qui dépendent directement d'une image de base: [`npm run update:images
+> <image-name>`](./SCRIPTS.md#updateimages).  Assurez-vous que l'image a été créée (version, build, push)
+> avant de lancer le script.
+
 ## Création d'une version
 
 Une version se crée manuellement. Pour ça il faut se déplacer dans le

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,54 @@ automatiquement à la version demandée, en arrivant à la racine du répertoire
 [nvm / Deeper Shell
 integration](https://github.com/nvm-sh/nvm#deeper-shell-integration).
 
+Pour VSCode, il est recommnandé d'accepter l'installation de l'extension
+[EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig).
+
+## Nouvelle branche
+
+La branche principale (`main`) du dépôt est protégée.  
+Ça signifie que pour contribuer au dépôt, il faut passer par le mécanisme des
+*pull requests*.  
+
+Et pour créer une *pull request* (ou contribution), il faut d'abord créer une branche.  
+
+Son nom est important, car il permettra aux *GitHub Actions* automatiques
+d'obtenir des informations sur la partie du dépôt qui est travaillée.  
+
+Les noms des branches auront 3 parties:
+
+1. `services` pour indiquer qu'on travaille dans le répertoire des services
+2. le nom du service (ou de l'image de base) concerné(e) (en deux parties
+   séparées par un tiret, suivant la convention de nommage des *containers* dans
+   [ezmaster](https://github.com/Inist-CNRS/ezmaster)), correspondant au nom du
+   répertoire (donc sans `ws-`)
+3. le détail de l'opération. C'est un commentaire (où il faut séparer les mots
+   par des tirets)
+
+Chacune de ces parties sera écrite en minuscules, sans accent, sans espace, et
+elles seront séparées par le caractère `/`.
+
+Par exemple, pour améliorer le service `base-line`, et lui ajouter une route
+`v1/lowercase`, on pourrait créer une branche nommée
+`services/base-line/add-route-lowercase`.
+
+Ainsi, c'est le service `base-line` qui sera concerné par les actions
+automatiques.  
+
+D'autres exemples de noms de branche:
+
+- `services/base-line-python/make-python-script-executable`
+- `services/base-line/change-required-input-for-no-accent`
+- `services/terms-teeft/add-teeft-with-number`
+- `docs/contributing/add-new-branch`
+
+> **Remarque** : seules branches commençant par `services/` et contenant deux
+> `/` déclencheront l'action de test du service.
+
+> **Remarque** : comme nous construisons des programmes *open source*, tâchons
+> de garder tout ce qui est technique (ça peut exclure la documentation
+> elle-même) en anglais.
+
 ## Création d'un service
 
 Avant toute chose, il faut s'assurer qu'un service qui pourrait accueillir votre
@@ -354,51 +402,6 @@ Il y a plusieurs images de base:
   serveur ezs vide, acceptant les scripts ezs et python, embarquant saxon, sous
   la forme de la commande `xslt`.
 
-## Nouvelle branche
-
-La branche principale (`main`) du dépôt est protégée.  
-Ça signifie que pour contribuer au dépôt, il faut passer par le mécanisme des
-*pull requests*.  
-
-Et pour créer une *pull request* (ou contribution), il faut d'abord créer une branche.  
-
-Son nom est important, car il permettra aux *GitHub Actions* automatiques
-d'obtenir des informations sur la partie du dépôt qui est travaillée.  
-
-Les noms des branches auront 3 parties:
-
-1. `services` pour indiquer qu'on travaille dans le répertoire des services
-2. le nom du service (ou de l'image de base) concerné(e) (en deux parties
-   séparées par un tiret, suivant la convention de nommage des *containers* dans
-   [ezmaster](https://github.com/Inist-CNRS/ezmaster)), correspondant au nom du
-   répertoire (donc sans `ws-`)
-3. le détail de l'opération. C'est un commentaire (où il faut séparer les mots
-   par des tirets)
-
-Chacune de ces parties sera écrite en minuscules, sans accent, sans espace, et
-elles seront séparées par le caractère `/`.
-
-Par exemple, pour améliorer le service `base-line`, et lui ajouter une route
-`v1/lowercase`, on pourrait créer une branche nommée
-`services/base-line/add-route-lowercase`.
-
-Ainsi, c'est le service `base-line` qui sera concerné par les actions
-automatiques.  
-
-D'autres exemples de noms de branche:
-
-- `services/base-line-python/make-python-script-executable`
-- `services/base-line/change-required-input-for-no-accent`
-- `services/terms-teeft/add-teeft-with-number`
-- `docs/contributing/add-new-branch`
-
-> **Remarque** : seules branches commençant par `services/` et contenant deux
-> `/` déclencheront l'action de test du service.
-
-> **Remarque** : comme nous construisons des programmes *open source*, tâchons
-> de garder tout ce qui est technique (ça peut exclure la documentation
-> elle-même) en anglais.
-
 ## Création d'une version
 
 Une version se crée manuellement. Pour ça il faut se déplacer dans le
@@ -411,8 +414,8 @@ le tout sur GitHub, déclenchant une action de Github qui poussera
 automatiquement l'image sur Docker Hub.
 
 > **Remarque**: on peut aussi utiliser l'option *workspace* `-w` de npm pour
-> créer la version depuis la racine du dépôt: `npm version -w
-> services/service-name patch`.
+> créer la version depuis la racine du dépôt: `npm -w services/service-name
+> version patch`.
 
 ## Mise en production
 

--- a/SCRIPTS.md
+++ b/SCRIPTS.md
@@ -7,6 +7,7 @@ Available scripts:
 - generate:service
 - help
 - publish
+- update:images
 - test:local
 - test:remote
 - test:remotes
@@ -72,6 +73,89 @@ Publish all services:
 
 All services with a `swagger.json` containing an enabled `servers.url` (with a
 `standard` value for `x-profil`) are published.
+
+## update:images
+
+Usage `npm run update:images -- [--help | [--dry-run] <[bases/]image-name>]`
+
+Required: `image-name` should be a base image name, or a path to a base image
+(`bases/image-name`).
+
+Update all `Dockerfile`s directly depending from a base image.  
+Update the template too, when it is the image used.  
+
+> **Note**: when a base image depends from the given image, it will be updated,
+> but no service depending from the latter will be updated, you have to run the
+> script again, using the name of the latter image.
+
+> **Reminder**: don't forget to build and push the base image before using this
+> script.
+
+### Parameters
+
+- `--dry-run`: allow you to test your parameters, and will not execute any
+  command, only show you what commands would be executed.
+- `--help`: show the usage of the command
+
+> **Note**: you only need `-- ` after script name when you use an option
+> (beginning with `--`)
+
+### Examples
+
+```bash
+$ npm run update:images -- --dry-run bases/ezs-python-server
+
+> web-services@1.0.0 update:images
+> ./bin/update-images.sh --dry-run bases/ezs-python-server
+
+Update images depending from ezs-python-server (level )
+
+Tag of the image: py3.9-no16-1.0.7
+
+Directly depending images:
+ - bases/ezs-python-saxon-server/Dockerfile
+ - services/base-line/Dockerfile
+ - services/base-line-python/Dockerfile
+ - services/terms-extraction/Dockerfile
+ - template/Dockerfile
+
+Updating images:
+
+ - bases/ezs-python-saxon-server/Dockerfile
+sed -i -e "s/cnrsinist\/ezs-python-server:.*$/cnrsinist\/ezs-python-server:py3.9-no16-1.0.7/g" "bases/ezs-python-saxon-server/Dockerfile"
+npm -w "bases/ezs-python-saxon-server" version patch
+npm -w "bases/ezs-python-saxon-server" run build
+npm -w "bases/ezs-python-saxon-server" run publish
+
+***** Don't forget to run "updateBase bases/ezs-python-saxon-server" *******
+
+ - services/base-line/Dockerfile
+sed -i -e "s/cnrsinist\/ezs-python-server:.*$/cnrsinist\/ezs-python-server:py3.9-no16-1.0.7/g" "services/base-line/Dockerfile"
+npm -w "services/base-line" version patch
+
+ - services/base-line-python/Dockerfile
+sed -i -e "s/cnrsinist\/ezs-python-server:.*$/cnrsinist\/ezs-python-server:py3.9-no16-1.0.7/g" "services/base-line-python/Dockerfile"
+npm -w "services/base-line-python" version patch
+
+ - services/terms-extraction/Dockerfile
+sed -i -e "s/cnrsinist\/ezs-python-server:.*$/cnrsinist\/ezs-python-server:py3.9-no16-1.0.7/g" "services/terms-extraction/Dockerfile"
+npm -w "services/terms-extraction" version patch
+
+ - template/Dockerfile
+sed -i -e "s/cnrsinist\/ezs-python-server:.*$/cnrsinist\/ezs-python-server:py3.9-no16-1.0.7/g" "template/Dockerfile"
+git add template
+git commit -m "Update template to ezs-python-server:py3.9-no16-1.0.7"
+git push
+```
+
+```bash
+$ npm run update:images -- --help
+
+> web-services@1.0.0 update:images
+> ./bin/update-images.sh --help
+
+Usage: ./bin/update-images.sh [--help | [--dry-run] <[bases/]image-name>]
+```
 
 ## test:local
 

--- a/bases/ezs-python-saxon-server/Dockerfile
+++ b/bases/ezs-python-saxon-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.7
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.8
 
 ARG saxon_ver=10.9
 ENV SAXON_HOME=/usr/share/java/saxon

--- a/bases/ezs-python-saxon-server/README.md
+++ b/bases/ezs-python-saxon-server/README.md
@@ -1,4 +1,4 @@
-# ezs-python-saxon-server@1.0.1
+# ezs-python-saxon-server@1.0.2
 
 Ce répertoire contient de quoi construire une image Docker lançant un serveur
 [ezs](https://github.com/Inist-CNRS/ezs) ayant la possibilité de lancer des

--- a/bases/ezs-python-saxon-server/package.json
+++ b/bases/ezs-python-saxon-server/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ezs-python-saxon-server",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "ezs server + python + saxon",
     "repository": {
         "type": "git",

--- a/bases/ezs-python-server/Dockerfile
+++ b/bases/ezs-python-server/Dockerfile
@@ -9,9 +9,9 @@ RUN apt update && apt install -y tini && \
 
 WORKDIR /app
 RUN npm install dotenv-cli@7.3.0 && \
-    npm install @ezs/core@3.4.4 && \
-    npm install @ezs/analytics@2.2.1 && \
-    npm install @ezs/basics@2.5.8 && \
+    npm install @ezs/core@3.6.0 && \
+    npm install @ezs/analytics@2.2.2 && \
+    npm install @ezs/basics@2.6.0 && \
     npm install @ezs/spawn@1.4.5 && \
     chmod a+w /app
 

--- a/bases/ezs-python-server/README.md
+++ b/bases/ezs-python-server/README.md
@@ -1,4 +1,4 @@
-# ezs-python-server@1.0.7
+# ezs-python-server@1.0.8
 
 Ce répertoire contient de quoi construire une image Docker lançant un serveur
 [ezs](https://github.com/Inist-CNRS/ezs) ayant la possibilité de lancer des

--- a/bases/ezs-python-server/package.json
+++ b/bases/ezs-python-server/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ezs-python-server",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "description": "ezs server + python",
     "repository": {
         "type": "git",

--- a/bin/dry-run.sh
+++ b/bin/dry-run.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2148
 function run() {
     printf "%s\n" "$*"
 }

--- a/bin/update-images.sh
+++ b/bin/update-images.sh
@@ -58,7 +58,7 @@ function updateBase() {
 
     printf "Directly depending images:\n"
 
-    DEPENDING_DOCKERFILES=$(grep -i "^FROM cnrsinist/$CHANGING_BASE:$BASE_IMAGE_TAG" $DOCKERFILES | sed -e 's/:.*$//')
+    DEPENDING_DOCKERFILES=$(grep -i "^FROM cnrsinist/$CHANGING_BASE:" $DOCKERFILES | sed -e 's/:.*$//')
 
     for DOCKERFILE in $DEPENDING_DOCKERFILES
     do

--- a/bin/update-images.sh
+++ b/bin/update-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function usage() {
-    printf "Usage: ./bin/update-images.sh [--help | [--dry-run] <service-name>]\n"
+    printf "Usage: ./bin/update-images.sh [--help | [--dry-run] <[bases/]image-name>]\n"
 }
 
 DRY=false
@@ -15,7 +15,7 @@ for arg in "$@"; do
             ;;
         --help)
             usage
-            exit 1
+            exit 0
             ;;
         *)
             TO_UPDATE="$arg"

--- a/bin/wet-run.sh
+++ b/bin/wet-run.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2148
 function run() {
-    exec "$*"
+    eval "$*"
 }

--- a/package.json
+++ b/package.json
@@ -1,53 +1,54 @@
 {
-  "private": true,
-  "name": "web-services",
-  "version": "1.0.0",
-  "description": "Web services at Inist-CNRS",
-  "main": "index.js",
-  "scripts": {
-    "generate:example-metadata": "node bin/generate-example-metadata.mjs",
-    "generate:example-tests": "node bin/generate-example-tests.mjs",
-    "generate:service": "./bin/create-service-from-template.sh",
-    "help": "bat SCRIPTS.md || cat SCRIPTS.md",
-    "publish": "./bin/publish.sh",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "test:local": "bin/test-service.sh local",
-    "test:remote": "bin/test-service.sh remote",
-    "test:remotes": "bin/test-services.sh"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Inist-CNRS/web-services.git"
-  },
-  "keywords": [
-    "webservices",
-    "tdm"
-  ],
-  "author": "",
-  "license": "CECILL-2.1",
-  "bugs": {
-    "url": "https://github.com/Inist-CNRS/web-services/issues"
-  },
-  "homepage": "https://github.com/Inist-CNRS/web-services#readme",
-  "workspaces": [
-    "bases/ezs-python-saxon-server",
-    "bases/ezs-python-server",
-    "bases/python-node",
-    "services/affiliation-rnsr",
-    "services/base-line",
-    "services/base-line-python",
-    "services/biblio-ref",
-    "services/terms-extraction"
-  ],
-  "dependencies": {
-    "@ezs/analytics": "2.2.1",
-    "@ezs/basics": "2.5.8",
-    "@ezs/core": "3.4.4",
-    "@ezs/spawn": "1.4.5",
-    "@orangeopensource/hurl": "4.1.0",
-    "rest-cli": "1.8.13"
-  },
-  "devDependencies": {
-    "@types/node": "20.10.4"
-  }
+    "private": true,
+    "name": "web-services",
+    "version": "1.0.0",
+    "description": "Web services at Inist-CNRS",
+    "main": "index.js",
+    "scripts": {
+        "generate:example-metadata": "node bin/generate-example-metadata.mjs",
+        "generate:example-tests": "node bin/generate-example-tests.mjs",
+        "generate:service": "./bin/create-service-from-template.sh",
+        "help": "bat SCRIPTS.md || cat SCRIPTS.md",
+        "publish": "./bin/publish.sh",
+        "update:images": "./bin/update-images.sh",
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "test:local": "bin/test-service.sh local",
+        "test:remote": "bin/test-service.sh remote",
+        "test:remotes": "bin/test-services.sh"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Inist-CNRS/web-services.git"
+    },
+    "keywords": [
+        "webservices",
+        "tdm"
+    ],
+    "author": "",
+    "license": "CECILL-2.1",
+    "bugs": {
+        "url": "https://github.com/Inist-CNRS/web-services/issues"
+    },
+    "homepage": "https://github.com/Inist-CNRS/web-services#readme",
+    "workspaces": [
+        "bases/ezs-python-saxon-server",
+        "bases/ezs-python-server",
+        "bases/python-node",
+        "services/affiliation-rnsr",
+        "services/base-line",
+        "services/base-line-python",
+        "services/biblio-ref",
+        "services/terms-extraction"
+    ],
+    "dependencies": {
+        "@ezs/analytics": "2.2.1",
+        "@ezs/basics": "2.5.8",
+        "@ezs/core": "3.4.4",
+        "@ezs/spawn": "1.4.5",
+        "@orangeopensource/hurl": "4.1.0",
+        "rest-cli": "1.8.13"
+    },
+    "devDependencies": {
+        "@types/node": "20.10.4"
+    }
 }

--- a/services/affiliation-rnsr/Dockerfile
+++ b/services/affiliation-rnsr/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=secret,id=webdav_login \
 COPY ./v3/affiliation/models.dvc /dvc
 RUN dvc pull -v
 
-FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.6 AS release
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.8
 
 USER root
 # Install all python dependencies

--- a/services/affiliation-rnsr/README.md
+++ b/services/affiliation-rnsr/README.md
@@ -1,4 +1,4 @@
-# ws-affiliation-rnsr@2.1.3
+# ws-affiliation-rnsr@2.1.4
 
 Trouve un RNSR à partir d'une affiliation.
 

--- a/services/affiliation-rnsr/package.json
+++ b/services/affiliation-rnsr/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-affiliation-rnsr",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "description": "Trouve un RNSR à partir d'une affiliation.",
     "repository": {
         "type": "git",

--- a/services/affiliation-rnsr/swagger.json
+++ b/services/affiliation-rnsr/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "affiliation-rnsr - Trouve un RNSR à partir d'une affiliation.",
 		"summary": "Pour chaque affiliation séparées par un point virgule, retourne un RNSR. Retourne n/a si aucun RNSR n'est trouvé.",
-		"version": "2.1.3",
+		"version": "2.1.4",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/services/base-line-python/Dockerfile
+++ b/services/base-line-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.7
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.8
 
 USER root
 RUN pip install unidecode==1.3.7

--- a/services/base-line-python/README.md
+++ b/services/base-line-python/README.md
@@ -1,4 +1,4 @@
-# ws-base-line-python@1.0.7
+# ws-base-line-python@1.0.8
 
 Services dédiés aux tests.
 

--- a/services/base-line-python/package.json
+++ b/services/base-line-python/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-base-line-python",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "description": "Base line web services in Python",
     "repository": {
         "type": "git",

--- a/services/base-line-python/swagger.json
+++ b/services/base-line-python/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "base-line-python - Services en python dédiés aux tests",
 		"summary": "Vérifie la faisabilité de services en python",
-		"version": "1.0.7",
+		"version": "1.0.8",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/services/base-line/Dockerfile
+++ b/services/base-line/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.7
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.8
 
 # USER daemon
 WORKDIR /app/public

--- a/services/base-line/README.md
+++ b/services/base-line/README.md
@@ -1,4 +1,4 @@
-# ws-base-line@1.0.9
+# ws-base-line@1.0.10
 
 Services dédiés aux tests.
 

--- a/services/base-line/package.json
+++ b/services/base-line/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-base-line",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "description": "Base line web services",
     "repository": {
         "type": "git",

--- a/services/base-line/swagger.json
+++ b/services/base-line/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "base-line - Services dédiés aux tests",
 		"summary": "Propose plusieurs services ne proposant aucun traitement ce qui permet de vérfier ou mesurer les connexions ou les temps de réponse",
-		"version": "1.0.9",
+		"version": "1.0.10",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/services/biblio-ref/Dockerfile
+++ b/services/biblio-ref/Dockerfile
@@ -15,7 +15,7 @@ RUN dvc doctor
 COPY ./v1/annulled.csv.dvc /dvc
 RUN dvc pull -v
 
-FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.6 as release
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.8
 
 USER root
 # Install all python dependencies

--- a/services/biblio-ref/README.md
+++ b/services/biblio-ref/README.md
@@ -1,4 +1,4 @@
-# ws-biblio-ref@1.0.0
+# ws-biblio-ref@1.0.1
 
 Valide une référence bibliographique
 

--- a/services/biblio-ref/package.json
+++ b/services/biblio-ref/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-biblio-ref",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Valide une référence bibliographique",
     "repository": {
         "type": "git",

--- a/services/biblio-ref/swagger.json
+++ b/services/biblio-ref/swagger.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "biblio-ref - Valide une référence bibliographique",
 		"summary": "Si un DOI est trouvé dans la référence bibliographique, valide la référence et indique si elle est rétractée",
-		"version": "1.0.0",
+		"version": "1.0.1",
 		"termsOfService": "https://services.istex.fr/",
 		"contact": {
 			"name": "Inist-CNRS",

--- a/services/terms-extraction/Dockerfile
+++ b/services/terms-extraction/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.7
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.8
 
 USER root
 

--- a/services/terms-extraction/README.md
+++ b/services/terms-extraction/README.md
@@ -1,4 +1,4 @@
-# ws-terms-extraction@1.5.2
+# ws-terms-extraction@1.5.3
 
 Extraction de termes
 

--- a/services/terms-extraction/package.json
+++ b/services/terms-extraction/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-terms-extraction",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "description": "Extraction de termes",
     "repository": {
         "type": "git",

--- a/services/terms-extraction/swagger.json
+++ b/services/terms-extraction/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "terms-extraction - Extraction de termes",
         "summary": "Extraction de termes à partir de textes en anglais ou en français.",
-        "version": "1.5.2",
+        "version": "1.5.3",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.7
+FROM cnrsinist/ezs-python-server:py3.9-no16-1.0.8
 
 USER root
 # Install all python dependencies


### PR DESCRIPTION
First real test of the `update-images.sh` shell script.

This version of `@ezs/core` allows to use multiline markdown in `.ini` metadata.