### PR TITLE
Make ezmaster take config.json into account

### DIFF
--- a/services/affiliation-rnsr/Dockerfile
+++ b/services/affiliation-rnsr/Dockerfile
@@ -26,6 +26,6 @@ WORKDIR /app/public
 # A modifier : (utiliser le .dockerignore)
 COPY --chown=daemon:daemon ./v2/affiliation /app/public/v2/affiliation
 COPY --chown=daemon:daemon ./v3/affiliation /app/public/v3/affiliation
-
+RUN mv ./config.json /app && chmod a+w /app/config.json
 
 COPY --chown=daemon:daemon --from=build1 /dvc/models /app/public/v3/affiliation/models

--- a/services/chem-ner/Dockerfile
+++ b/services/chem-ner/Dockerfile
@@ -25,5 +25,6 @@ WORKDIR /app/public
 # Declare files to copy in .dockerignore
 # A modifier : (utiliser le .dockerignore)
 COPY --chown=daemon:daemon . /app/public/
+RUN mv ./config.json /app && chmod a+w /app/config.json
 
 COPY --chown=daemon:daemon --from=build1 /dvc/models /app/public/v1/chem/models

--- a/services/diseases-ner/Dockerfile
+++ b/services/diseases-ner/Dockerfile
@@ -25,5 +25,6 @@ WORKDIR /app/public
 # Declare files to copy in .dockerignore
 # A modifier : (utiliser le .dockerignore)
 COPY --chown=daemon:daemon . /app/public/
+RUN mv ./config.json /app && chmod a+w /app/config.json
 
 COPY --chown=daemon:daemon --from=build1 /dvc/models /app/public/v1/diseases/models

--- a/services/terms-extraction/Dockerfile
+++ b/services/terms-extraction/Dockerfile
@@ -10,3 +10,4 @@ RUN npm install \
 WORKDIR /app/public
 # Declare files to copy in .dockerignore
 COPY --chown=daemon:daemon . /app/public/
+RUN mv ./config.json /app && chmod a+w /app/config.json

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -14,3 +14,4 @@ USER root
 WORKDIR /app/public
 # Declare files to copy in .dockerignore
 COPY --chown=daemon:daemon . /app/public/
+RUN mv ./config.json /app && chmod a+w /app/config.json


### PR DESCRIPTION
It was wrongly located: all files were copied into `/app/public`, including `config.json`.

But the [`ezs-python-server`'s `Dockerfile`](https://github.com/Inist-CNRS/web-services/blob/a2ec787a3a1c0c4fa60a31be64ef9f8c7660edad/bases/ezs-python-server/Dockerfile#L6) states that ezmaster's configuration file path is `/app/config.json`:

```Dockerfile
RUN apt update && apt install -y tini && \
    echo '{ \
    "httpPort": 31976, \
    "configPath": "/app/config.json", \
    "dataPath": "/app/public" \
    }' > /etc/ezmaster.json
```