### PR TITLE
data-computer: fix /tmp

### DIFF
--- a/services/data-computer/README.md
+++ b/services/data-computer/README.md
@@ -1,4 +1,4 @@
-# ws-data-computer@2.10.0
+# ws-data-computer@2.10.1
 
 Le service `data-computer` offre plusieurs services **asynchrones** pour des calculs et de transformations de données simples.
 

--- a/services/data-computer/package.json
+++ b/services/data-computer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-data-computer",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "Calculs sur fichier corpus compressé",
     "repository": {
         "type": "git",

--- a/services/data-computer/swagger.json
+++ b/services/data-computer/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "data-computer - Calculs sur fichier corpus compressé",
         "summary": "Calculs sur un corpus compressé",
-        "version": "2.10.0",
+        "version": "2.10.1",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/services/data-computer/swagger.json
+++ b/services/data-computer/swagger.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "title": "data-computer - Calculs sur fichier corpus compressé",
-        "summary": "Algorithmes de calculs sur un corpus compressé",
+        "summary": "Calculs sur un corpus compressé",
         "version": "2.10.0",
         "termsOfService": "https://services.istex.fr/",
         "contact": {


### PR DESCRIPTION
#75 did fix the `/tmp` problem
(see #68)
But the tag seems to not match the code in #75 (there was problem at `git push --tags`).

Let's create a patch version to get the fixed files in the Docker image.