### PR TITLE
fix(data-computer): fix dependencies of LDA route

### DIFF
--- a/services/data-computer/Dockerfile
+++ b/services/data-computer/Dockerfile
@@ -30,7 +30,8 @@ RUN pip install \
     fr_core_news_sm@https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.6.0/fr_core_news_sm-3.6.0-py3-none-any.whl \
     sentence-transformers==2.2.2 \
     umap-learn==0.5.5 \
-    scikit-learn==1.4.1.post1
+    scikit-learn==1.4.1.post1 \
+    scipy==1.10.1
 
 # Install all node dependencies
 RUN npm install \

--- a/services/data-computer/README.md
+++ b/services/data-computer/README.md
@@ -1,4 +1,4 @@
-# ws-data-computer@2.10.1
+# ws-data-computer@2.11.0
 
 Le service `data-computer` offre plusieurs services **asynchrones** pour des calculs et de transformations de données simples.
 

--- a/services/data-computer/package.json
+++ b/services/data-computer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-data-computer",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "Calculs sur fichier corpus compressé",
     "repository": {
         "type": "git",

--- a/services/data-computer/swagger.json
+++ b/services/data-computer/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "data-computer - Calculs sur fichier corpus compressé",
         "summary": "Calculs sur un corpus compressé",
-        "version": "2.10.1",
+        "version": "2.11.0",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/services/data-computer/swagger.json
+++ b/services/data-computer/swagger.json
@@ -15,7 +15,7 @@
             "x-comment": "Will be automatically completed by the ezs server."
         },
         {
-            "url": "http://vptdmjobs.intra.inist.fr:49166/",
+            "url": "http://vptdmjobs.intra.inist.fr:49167/",
             "description": "Latest version for production",
             "x-profil": "Standard"
         }


### PR DESCRIPTION
Need scipy==1.10.1 becauser gensim is using a depreciate function of scipy in v1.11+