### PR TITLE
affiliations-tools: update ezs conditor to 2.12

### DIFF
--- a/services/affiliations-tools/Dockerfile
+++ b/services/affiliations-tools/Dockerfile
@@ -37,7 +37,7 @@ WORKDIR /app/public
 # Install all node dependencies
 RUN npm install \
     @ezs/libpostal@0.3.0 \
-    @ezs/conditor@2.11.0
+    @ezs/conditor@2.12.0
 
 # If issues with bindings with version of node higher than 20, try adding this line
 # RUN cd node_modules/node_postal && npm run install

--- a/services/affiliations-tools/README.md
+++ b/services/affiliations-tools/README.md
@@ -1,4 +1,4 @@
-# ws-affiliations-tools@1.1.5
+# ws-affiliations-tools@1.1.6
 
 Structuration et enrichissements d'affiliations
 

--- a/services/affiliations-tools/package.json
+++ b/services/affiliations-tools/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-affiliations-tools",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "description": "Structuration et enrichissements d'affiliations",
     "repository": {
         "type": "git",

--- a/services/affiliations-tools/swagger.json
+++ b/services/affiliations-tools/swagger.json
@@ -15,7 +15,7 @@
             "x-comment": "Will be automatically completed by the ezs server."
         },
         {
-            "url": "http://vptdmservices.intra.inist.fr:49256/",
+            "url": "http://vptdmservices.intra.inist.fr:49265/",
             "description": "Latest version for production",
             "x-profil": "Standard"
         }

--- a/services/affiliations-tools/swagger.json
+++ b/services/affiliations-tools/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "affiliations-tools - Structuration et enrichissements d'affiliations",
         "summary": "Propose plusieurs services autour des affiliations présentes dans les notices bibliographiques",
-        "version": "1.1.5",
+        "version": "1.1.6",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/services/affiliations-tools/tests.hurl
+++ b/services/affiliations-tools/tests.hurl
@@ -293,7 +293,7 @@ HTTP 200
             "intitule": "botAnique et Modélisation de l'Architecture des Plantes et des végétations",
             "sigle": "AMAP",
             "ville_postale": "MONTPELLIER CEDEX 5",
-            "code_postal": "34398",
+            "code_postal": 34398,
             "etabAssoc": [
                 {
                     "etab": {
@@ -304,7 +304,7 @@ HTTP 200
                     },
                     "label": "UMR",
                     "labelAppauvri": "umr",
-                    "numero": "5120"
+                    "numero": 5120
                 },
                 {
                     "etab": {
@@ -315,7 +315,7 @@ HTTP 200
                     },
                     "label": "UMR",
                     "labelAppauvri": "umr",
-                    "numero": "5120"
+                    "numero": 5120
                 },
                 {
                     "etab": {
@@ -326,7 +326,7 @@ HTTP 200
                     },
                     "label": "UMR",
                     "labelAppauvri": "umr",
-                    "numero": "51"
+                    "numero": 51
                 },
                 {
                     "etab": {
@@ -337,7 +337,7 @@ HTTP 200
                     },
                     "label": "UMR",
                     "labelAppauvri": "umr",
-                    "numero": "5120"
+                    "numero": 5120
                 },
                 {
                     "etab": {
@@ -348,14 +348,14 @@ HTTP 200
                     },
                     "label": "UMR",
                     "labelAppauvri": "umr",
-                    "numero": "0931"
+                    "numero": 931
                 }
             ],
             "intituleAppauvri": "botanique et modelisation de l architecture des plantes et des vegetations",
             "sigleAppauvri": "amap",
             "ville_postale_appauvrie": "montpellier cedex 5",
-            "annee_creation": "2001",
-            "an_fermeture": ""
+            "annee_creation": 2001,
+            "an_fermeture": 0
         }
     ]
 },
@@ -364,10 +364,10 @@ HTTP 200
     "value": [
         {
             "num_nat_struct": "200711887V",
-            "intitule": "LABORATOIRE D'INTEGRATION DU MATERIAU AU SYSTEME",
+            "intitule": "Laboratoire d'intégration du matériau au système",
             "sigle": "IMS",
             "ville_postale": "TALENCE CEDEX",
-            "code_postal": "33405",
+            "code_postal": 33405,
             "etabAssoc": [
                 {
                     "etab": {
@@ -378,7 +378,7 @@ HTTP 200
                     },
                     "label": "UMR",
                     "labelAppauvri": "umr",
-                    "numero": "5218"
+                    "numero": 5218
                 },
                 {
                     "etab": {
@@ -389,7 +389,7 @@ HTTP 200
                     },
                     "label": "UMR",
                     "labelAppauvri": "umr",
-                    "numero": "5218"
+                    "numero": 5218
                 },
                 {
                     "etab": {
@@ -400,14 +400,14 @@ HTTP 200
                     },
                     "label": "UMR",
                     "labelAppauvri": "umr",
-                    "numero": "5218"
+                    "numero": 5218
                 }
             ],
             "intituleAppauvri": "laboratoire d integration du materiau au systeme",
             "sigleAppauvri": "ims",
             "ville_postale_appauvrie": "talence cedex",
-            "annee_creation": "2006",
-            "an_fermeture": ""
+            "annee_creation": 2006,
+            "an_fermeture": 0
         }
     ]
 },
@@ -431,7 +431,7 @@ HTTP 200
             "intitule": "Institut de l'information scientifique et technique",
             "sigle": "INIST",
             "ville_postale": "VANDOEUVRE LES NANCY CEDEX",
-            "code_postal": "54519",
+            "code_postal": 54519,
             "etabAssoc": [
                 {
                     "etab": {
@@ -442,14 +442,14 @@ HTTP 200
                     },
                     "label": "UAR",
                     "labelAppauvri": "uar",
-                    "numero": "76"
+                    "numero": 76
                 }
             ],
             "intituleAppauvri": "institut de l information scientifique et technique",
             "sigleAppauvri": "inist",
             "ville_postale_appauvrie": "vandoeuvre les nancy cedex",
-            "annee_creation": "1988",
-            "an_fermeture": ""
+            "annee_creation": 1988,
+            "an_fermeture": 0
         }
     ]
 }]

--- a/services/affiliations-tools/v1/rnsr/info.ini
+++ b/services/affiliations-tools/v1/rnsr/info.ini
@@ -78,7 +78,7 @@ post.responses.default.content.application/json.example.0.value.0.annee_creation
 post.responses.default.content.application/json.example.0.value.0.an_fermeture:
 post.responses.default.content.application/json.example.1.id: 3
 post.responses.default.content.application/json.example.1.value.0.num_nat_struct: 200711887V
-post.responses.default.content.application/json.example.1.value.0.intitule: LABORATOIRE D'INTEGRATION DU MATERIAU AU SYSTEME
+post.responses.default.content.application/json.example.1.value.0.intitule: Laboratoire d'intégration du matériau au système
 post.responses.default.content.application/json.example.1.value.0.sigle: IMS
 post.responses.default.content.application/json.example.1.value.0.ville_postale: TALENCE CEDEX
 post.responses.default.content.application/json.example.1.value.0.code_postal: 33405


### PR DESCRIPTION
To take 2023 RNSR's data into account, one has to update to `@ezs/conditor@2.12.0`.

Side effect: numbers are no longer strings, but... numbers.

See [`@ezs/conditor`](https://github.com/Inist-CNRS/ezs/pull/413): Inist-CNRS/ezs#413
See [ws-data](https://github.com/Inist-CNRS/ws-data/tree/master/rnsr).