### PR TITLE
[astro-ner]: Deploy 1.0.8

### DIFF
--- a/services/astro-ner/swagger.json
+++ b/services/astro-ner/swagger.json
@@ -15,7 +15,7 @@
             "x-comment": "Will be automatically completed by the ezs server."
         },
         {
-            "url": "http://vptdmservices.intra.inist.fr:49225/",
+            "url": "http://vptdmservices.intra.inist.fr:49275/",
             "description": "Latest version for production",
             "#DISABLED#x-profil": "Standard"
         }


### PR DESCRIPTION
The base image change did not work straight.

```Dockerfile
FROM python:3.9-slim-bullseye as dvcfiles
WORKDIR /dvc
RUN apt update && apt -y install git curl
RUN pip install dvc[webdav]==3.42.0
RUN --mount=type=secret,id=webdav_login \
    --mount=type=secret,id=webdav_password \
    --mount=type=secret,id=webdav_url \
    git init && \
    dvc init && \
    dvc remote add -d webdav-remote "$(cat /run/secrets/webdav_url)" && \
    dvc remote modify --local webdav-remote user "$(cat /run/secrets/webdav_login)" && \
    dvc remote modify --local webdav-remote password "$(cat /run/secrets/webdav_password)"
COPY ./v1/model.dvc /dvc
RUN dvc pull -v
RUN cat model/* > model.pt

FROM cnrsinist/ezs-python-pytorch-server:py3.9-no16-1.1.1

USER root
# RUN apt-get update && apt-get install -y --no-install-recommends \
#     build-essential \
#     libopenblas-dev \
#     libatlas-base-dev \
#     liblapack-dev \
#     gfortran \
#     && rm -rf /var/lib/apt/lists/*

ENV HF_HOME=/app/public/.huggingface

# COPY --chown=daemon:daemon requirements.txt /app/public/
# # Install all python dependencies
# RUN pip install --upgrade pip
# RUN pip install --no-deps -r /app/public/requirements.txt
# RUN pip install torch==1.10.2+cpu torchvision==0.11.3+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html

# Install all node dependencies
RUN npm install \
    @ezs/storage@3.2.3

WORKDIR /app/public
# Declare files to copy in .dockerignore
COPY --chown=daemon:daemon . /app/public/
RUN mv ./config.json /app && chmod a+w /app/config.json

COPY --chown=daemon:daemon --from=dvcfiles /dvc/model.pt /app/public/v1/model.pt
```

Builds correctly, but executes wrongly:

```log
Writing .env file... done.
/usr/local/lib/python3.9/site-packages/transformers/utils/hub.py:124: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
/usr/local/lib/python3.9/site-packages/transformers/utils/hub.py:124: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
Traceback (most recent call last):
  File "/app/public/./v1/find-astro.py", line 6, in <module>
    from flair.models import SequenceTagger
  File "/usr/local/lib/python3.9/site-packages/flair/__init__.py", line 20, in <module>
    from . import models
  File "/usr/local/lib/python3.9/site-packages/flair/models/__init__.py", line 1, in <module>
    from .sequence_tagger_model import SequenceTagger, MultiTagger
  File "/usr/local/lib/python3.9/site-packages/flair/models/sequence_tagger_model.py", line 20, in <module>
    from flair.embeddings import TokenEmbeddings, StackedEmbeddings, Embeddings
  File "/usr/local/lib/python3.9/site-packages/flair/embeddings/__init__.py", line 6, in <module>
    from .token import TokenEmbeddings
  File "/usr/local/lib/python3.9/site-packages/flair/embeddings/token.py", line 11, in <module>
    import gensim
  File "/usr/local/lib/python3.9/site-packages/gensim/__init__.py", line 11, in <module>
    from gensim import parsing, corpora, matutils, interfaces, models, similarities, utils  # noqa:F401
  File "/usr/local/lib/python3.9/site-packages/gensim/corpora/__init__.py", line 6, in <module>
    from .indexedcorpus import IndexedCorpus  # noqa:F401 must appear before the other classes
  File "/usr/local/lib/python3.9/site-packages/gensim/corpora/indexedcorpus.py", line 14, in <module>
    from gensim import interfaces, utils
  File "/usr/local/lib/python3.9/site-packages/gensim/interfaces.py", line 19, in <module>
    from gensim import utils, matutils
  File "/usr/local/lib/python3.9/site-packages/gensim/matutils.py", line 20, in <module>
    from scipy.linalg import get_blas_funcs, triu
ImportError: cannot import name 'triu' from 'scipy.linalg' (/usr/local/lib/python3.9/site-packages/scipy/linalg/__init__.py)
Traceback (most recent call last):
  File "/app/public/./v1/find-astro.py", line 6, in <module>
    from flair.models import SequenceTagger
  File "/usr/local/lib/python3.9/site-packages/flair/__init__.py", line 20, in <module>
    from . import models
  File "/usr/local/lib/python3.9/site-packages/flair/models/__init__.py", line 1, in <module>
    from .sequence_tagger_model import SequenceTagger, MultiTagger
  File "/usr/local/lib/python3.9/site-packages/flair/models/sequence_tagger_model.py", line 20, in <module>
    from flair.embeddings import TokenEmbeddings, StackedEmbeddings, Embeddings
  File "/usr/local/lib/python3.9/site-packages/flair/embeddings/__init__.py", line 6, in <module>
    from .token import TokenEmbeddings
  File "/usr/local/lib/python3.9/site-packages/flair/embeddings/token.py", line 11, in <module>
    import gensim
  File "/usr/local/lib/python3.9/site-packages/gensim/__init__.py", line 11, in <module>
    from gensim import parsing, corpora, matutils, interfaces, models, similarities, utils  # noqa:F401
  File "/usr/local/lib/python3.9/site-packages/gensim/corpora/__init__.py", line 6, in <module>
    from .indexedcorpus import IndexedCorpus  # noqa:F401 must appear before the other classes
  File "/usr/local/lib/python3.9/site-packages/gensim/corpora/indexedcorpus.py", line 14, in <module>
    from gensim import interfaces, utils
  File "/usr/local/lib/python3.9/site-packages/gensim/interfaces.py", line 19, in <module>
    from gensim import utils, matutils
  File "/usr/local/lib/python3.9/site-packages/gensim/matutils.py", line 20, in <module>
    from scipy.linalg import get_blas_funcs, triu
ImportError: cannot import name 'triu' from 'scipy.linalg' (/usr/local/lib/python3.9/site-packages/scipy/linalg/__init__.py)
```

Thus, we only deploy the 1.0.8 version.