### PR TITLE
Add get-production-versions shell script

### DIFF
--- a/bin/get-production-versions.sh
+++ b/bin/get-production-versions.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Usage: bin/test-services.sh [service-name]+
+
+set -u # No uninitialized variable
+set -o pipefail # Fail at first pipe error
+
+SERVICES=("$@") # Get all parameters
+
+for SERVICE in "${SERVICES[@]}"; do
+    SERVICE=${SERVICE#services/} # Remove `services/`
+
+    VERSION=$(curl -q "https://$SERVICE.services.istex.fr" 2> /dev/null | jq -r '.info.version' 2> /dev/null)
+    printf "%s\t%s\n" "$SERVICE" "$VERSION"
+done
+
+exit 0

--- a/services/base-line-python/package.json
+++ b/services/base-line-python/package.json
@@ -1,35 +1,36 @@
 {
-    "private": true,
-    "name": "ws-base-line-python",
-    "version": "1.0.11",
-    "description": "Base line web services in Python",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/Inist-CNRS/web-services.git"
-    },
-    "keywords": [
-        "ezmaster"
-    ],
-    "author": "Nicolas Thouvenin <touv@gmail.com>",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/Inist-CNRS/web-services/issues"
-    },
-    "homepage": "https://github.com/Inist-CNRS/web-services/#readme",
-    "scripts": {
-        "version:insert:readme": "sed -i \"s#\\(${npm_package_name}.\\)\\([\\.a-z0-9]\\+\\)#\\1${npm_package_version}#g\" README.md && git add README.md",
-        "version:insert:swagger": "sed -i \"s/\\\"version\\\": \\\"[0-9]\\+.[0-9]\\+.[0-9]\\+\\\"/\\\"version\\\": \\\"${npm_package_version}\\\"/g\" swagger.json && git add swagger.json",
-        "version:insert": "npm run version:insert:readme && npm run version:insert:swagger",
-        "version:commit": "git commit -a -m \"release ${npm_package_name}@${npm_package_version}\"",
-        "version:tag": "git tag \"${npm_package_name}@${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version}\"",
-        "version:push": "git push && git push --tags",
-        "version": "npm run version:insert && npm run version:commit && npm run version:tag",
-        "postversion": "npm run version:push",
-        "build:dev": "docker build -t cnrsinist/${npm_package_name}:latest .",
-        "start:dev": "npm run build:dev && docker run --name dev --rm --detach -p 31976:31976 cnrsinist/${npm_package_name}:latest",
-        "stop:dev": "docker stop dev",
-        "build": "docker build -t cnrsinist/${npm_package_name}:${npm_package_version} .",
-        "start": "docker run --rm -p 31976:31976 cnrsinist/${npm_package_name}:${npm_package_version}",
-        "publish": "docker push cnrsinist/${npm_package_name}:${npm_package_version}"
-    }
+  "private": true,
+  "name": "ws-base-line-python",
+  "version": "1.0.11",
+  "description": "Base line web services in Python",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Inist-CNRS/web-services.git"
+  },
+  "keywords": [
+    "ezmaster"
+  ],
+  "author": "Nicolas Thouvenin <touv@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Inist-CNRS/web-services/issues"
+  },
+  "homepage": "https://github.com/Inist-CNRS/web-services/#readme",
+  "scripts": {
+    "version:insert:readme": "sed -i \"s#\\(${npm_package_name}.\\)\\([\\.a-z0-9]\\+\\)#\\1${npm_package_version}#g\" README.md && git add README.md",
+    "version:insert:swagger": "sed -i \"s/\\\"version\\\": \\\"[0-9]\\+.[0-9]\\+.[0-9]\\+\\\"/\\\"version\\\": \\\"${npm_package_version}\\\"/g\" swagger.json && git add swagger.json",
+    "version:insert": "npm run version:insert:readme && npm run version:insert:swagger",
+    "version:commit": "git commit -a -m \"release ${npm_package_name}@${npm_package_version}\"",
+    "version:tag": "git tag \"${npm_package_name}@${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version}\"",
+    "version:push": "git push && git push --tags",
+    "version": "npm run version:insert && npm run version:commit && npm run version:tag",
+    "postversion": "npm run version:push",
+    "build:dev": "docker build -t cnrsinist/${npm_package_name}:latest .",
+    "start:dev": "npm run build:dev && docker run --name dev --rm --detach -p 31976:31976 cnrsinist/${npm_package_name}:latest",
+    "stop:dev": "docker stop dev",
+    "build": "docker build -t cnrsinist/${npm_package_name}:${npm_package_version} .",
+    "start": "docker run --rm -p 31976:31976 cnrsinist/${npm_package_name}:${npm_package_version}",
+    "publish": "docker push cnrsinist/${npm_package_name}:${npm_package_version}"
+  },
+  "avoid-testing": true
 }


### PR DESCRIPTION
Get the version of the service in production, according to the `swagger.json` it returns.

Example:

```bash
$ bin/get-production-versions.sh services/*
address-kit	2.1.2
affiliation-rnsr	3.4.4
affiliations-tools	1.1.8
ark-tools	1.28.3
astro-ner	1.0.10
authors-tools	2.5.4
base-line	1.0.13
base-line-python	
biblio-ref	1.4.1
biblio-tools	4.0.5
chem-ner	3.0.8
data-computer	2.12.6
data-termsuite	3.0.4
data-workflow	1.2.9
data-wrapper	1.3.5
diseases-ner	1.0.14
domains-classifier	1.5.2
funder-ner	1.0.4
hal-classifier	4.0.6
irc3-species	1.1.5
ner-tagger	1.0.8
nlp-tools2	2.0.5
pdf-text	1.1.2
sciencemetrix-classification	2.0.2
terms-extraction	1.6.2
```

> **Note**: in the example, `affiliation-rnsr`'s version according to `package.json` is `2.1.3`. 
> **Note2**: `base-line-python` does not exist in production, so no version number is given.