### PR TITLE
[template] Reduce default concurrency

### DIFF
--- a/template/config.json
+++ b/template/config.json
@@ -3,7 +3,7 @@
         "EZS_TITLE": "{short_description}",
         "EZS_DESCRIPTION": "{summary}",
         "EZS_METRICS": true,
-        "EZS_CONCURRENCY": 4,
+        "EZS_CONCURRENCY": 2,
         "EZS_CONTINUE_DELAY": 60,
         "EZS_NSHARDS": 32,
         "EZS_CACHE": true,


### PR DESCRIPTION
Because more is too much (with the current machine).