### PR TITLE
Add bin/test-services-tsv.sh

### DIFF
--- a/bin/test-services-tsv.sh
+++ b/bin/test-services-tsv.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Usage: bin/test-services.sh [service-name]+
+
+set -u # No uninitialized variable
+set -o pipefail # Fail at first pipe error
+
+SERVICES=("$@") # Get all parameters
+
+printf "service\tversion\tresult\n"
+
+for SERVICE in "${SERVICES[@]}"; do
+    SERVICE=${SERVICE#services/} # Remove `services/`
+    SERVICE=${SERVICE%/} # Remove trailing `/`
+
+    VERSION=$(curl -q "https://$SERVICE.services.istex.fr" 2> /dev/null | jq -r '.info.version' 2> /dev/null)
+
+    # Don't test if the package.json in the services/$SERVICE directory includes an "avoid-testing" key set to true
+    if grep -q '"avoid-testing": true' "services/$SERVICE/package.json"; then
+        printf "%s\t%s\tn/a\n" "$SERVICE" "$VERSION"
+        continue
+    fi
+
+    npx hurl --test --continue-on-error --variable host="https://$SERVICE.services.istex.fr" "services/$SERVICE/tests.hurl" 2> /dev/null
+    if [ $? -ne 0 ]; then
+        printf "%s\t%s\t❌\n" "$SERVICE" "$VERSION"
+    else
+        printf "%s\t%s\t✅\n" "$SERVICE" "$VERSION"
+    fi
+done
+
+exit 0


### PR DESCRIPTION
To Display test results of all services in production in TSV format.

Example:

```bash
 ./bin/test-services-tsv.sh services/* > /tmp/2024-07-22-services.tsv
```

You can even translate it to Markdown using [`tsv-to-markdown`](https://www.npmjs.com/package/csv-to-markdown):

| service                      | version | result |
| ---------------------------- | ------- | ------ |
| address-kit                  | 2.1.2   | ✅      |
| affiliation-rnsr             | 2.1.9   | ✅      |
| affiliations-tools           | 1.1.8   | ❌      |
| ark-tools                    | 1.28.3  | n/a    |
| astro-ner                    | 1.0.10  | ✅      |
| authors-tools                | 2.5.4   | ✅      |
| base-line                    | 1.0.13  | ✅      |
| base-line-python             |         | n/a    |
| biblio-ref                   | 1.4.1   | ✅      |
| biblio-tools                 | 4.0.5   | n/a    |
| chem-ner                     | 3.0.8   | ✅      |
| data-computer                | 2.12.6  | ✅      |
| data-termsuite               | 3.0.4   | ✅      |
| data-workflow                | 1.2.9   | ✅      |
| data-wrapper                 | 1.3.5   | ✅      |
| diseases-ner                 | 1.0.14  | ✅      |
| domains-classifier           | 1.5.2   | ✅      |
| funder-ner                   | 1.0.4   | ✅      |
| hal-classifier               | 4.0.6   | ✅      |
| irc3-species                 | 1.1.5   | ✅      |
| ner-tagger                   | 1.0.8   | ✅      |
| nlp-tools2                   | 2.0.5   | ✅      |
| pdf-text                     | 1.1.4   | ✅      |
| sciencemetrix-classification | 2.0.2   | ✅      |
| terms-extraction             | 1.6.2   | ✅      |