### PR TITLE
[vscode] add spelling extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,9 @@
 	"recommendations": [
         "anweber.vscode-httpyac",
         "davidanson.vscode-markdownlint",
-		"EditorConfig.EditorConfig"
+		"EditorConfig.EditorConfig",
+        "streetsidesoftware.code-spell-checker",
+        "streetsidesoftware.code-spell-checker-french"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,18 @@
         "MD051": false // MD051: Broken link fragment (ex: #v1/teeft instead of #v1teeft)
     },
     "cSpell.enableFiletypes": [
-        "ini"
+        "ini",
+        "properties"
     ],
-    "cSpell.language": "en,fr-FR"
+    "cSpell.language": "en,fr-FR",
+    "cSpell.words": [
+        "Bigramme",
+        "concat",
+        "inist",
+        "Lodex",
+        "prometheus",
+        "stopwords",
+        "ungroup",
+        "uuid"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,10 @@
         "MD024": false, // MD024: Duplicate headings
         "MD028": false, // MD028: Blank line inside blockquote
         "MD041": false, // MD041: First line in file should be a top level header
-        "MD051": false  // MD051: Broken link fragment (ex: #v1/teeft instead of #v1teeft)
-    }
+        "MD051": false // MD051: Broken link fragment (ex: #v1/teeft instead of #v1teeft)
+    },
+    "cSpell.enableFiletypes": [
+        "ini"
+    ],
+    "cSpell.language": "en,fr-FR"
 }

--- a/services/data-computer/v1/graph-segment.ini
+++ b/services/data-computer/v1/graph-segment.ini
@@ -41,7 +41,7 @@ plugin = analytics
 [delegate]
 file = charger.cfg
 
-# Step 1.1 (spécifique): Controle du premier element en supposant que les autres lui ressemblent
+# Step 1.1 (spécifique): Contrôle du premier element en supposant que les autres lui ressemblent
 [singleton]
 [singleton/validate]
 path = id
@@ -50,7 +50,7 @@ rule = required
 path = value
 rule = required|array
 
-# Step 2 (générique): Traiter de manière asynchnore les items reçus
+# Step 2 (générique): Traiter de manière asynchrone les items reçus
 [fork]
 standalone = true
 logger = logger.cfg
@@ -74,7 +74,7 @@ identifier = id
 # Step 2.1.3 (spécifique): Regrouper les segments
 [fork/delegate/aggregate]
 
-# Step 2.1.4 (spécifique): Construire un résulat spécifique du calcul
+# Step 2.1.4 (spécifique): Construire un résultat spécifique du calcul
 [fork/delegate/replace]
 path = source
 value = get('id.0')
@@ -91,7 +91,7 @@ value = get('value').uniq()
 [fork/delegate]
 file = recorder.cfg
 
-# Step 3 : Renvoyer immédiatement un seul élément indiquant comment récupérer le résulat quand il sera prêt
+# Step 3 : Renvoyer immédiatement un seul élément indiquant comment récupérer le résultat quand il sera prêt
 [delegate]
 file = recipient.cfg
 

--- a/services/data-computer/v1/lda-segment.cfg
+++ b/services/data-computer/v1/lda-segment.cfg
@@ -11,12 +11,12 @@ command = ./v1/lda.py
 args = fix('-p')
 args = env('nbTopic',15)
 
-# Step 2.1.1 (spécifique): Propose un reformatage de sortie pour usage simplifier dans lodex
+# Step 2.1.1 (spécifique): Propose un reformatage de sortie pour usage simplifier dans Lodex
 [exchange]
 value = get('value.topics').map((o, i) => _.zip(o.words, o.words_weights).map(x=>x.concat(i).concat(o.topic_weight))).flatten().map(y=> ({source: y[0], target: y[2], weight: y[1], origin: self.id})).filter(Boolean)
 [ungroup]
 
-# Step 2.1.2 (spécifique): On regoupe les origin par segments identiques
+# Step 2.1.2 (spécifique): On regroupe les origin par segments identiques
 [replace]
 path = id
 value = self().omit(['uuid', 'origin'])


### PR DESCRIPTION
See <https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker>.

`Ctrl`-`.` is the shortcut.

These extensions are recommended, but not required.