### PR TITLE
[data-computer]: Use ezs packages from base image

### DIFF
--- a/services/data-computer/Dockerfile
+++ b/services/data-computer/Dockerfile
@@ -15,12 +15,6 @@ RUN pip install \
     scipy==1.10.1 \
     prometheus-client==0.19.0
 
-# Install all node dependencies
-RUN npm install \
-    "@ezs/analytics@2.2.2" \
-    "@ezs/basics@2.6.0" \
-    "@ezs/core@3.6.0" \
-    "@ezs/spawn@1.4.5"
 # Install CURL to get spacy_lefff model and put it at the right place
 RUN apt update && apt -y install curl tar
 RUN curl -L -O https://github.com/sammous/spacy-lefff-model/releases/latest/download/model.tar.gz

--- a/services/data-computer/README.md
+++ b/services/data-computer/README.md
@@ -1,4 +1,4 @@
-# ws-data-computer@2.12.6
+# ws-data-computer@2.12.7
 
 Le service `data-computer` offre plusieurs services **asynchrones** pour des calculs et de transformations de données simples.
 

--- a/services/data-computer/README.md
+++ b/services/data-computer/README.md
@@ -1,4 +1,4 @@
-# ws-data-computer@2.12.7
+# ws-data-computer@2.12.8
 
 Le service `data-computer` offre plusieurs services **asynchrones** pour des calculs et de transformations de données simples.
 

--- a/services/data-computer/package.json
+++ b/services/data-computer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-data-computer",
-    "version": "2.12.7",
+    "version": "2.12.8",
     "description": "Calculs sur fichier corpus compressé",
     "repository": {
         "type": "git",

--- a/services/data-computer/package.json
+++ b/services/data-computer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-data-computer",
-    "version": "2.12.6",
+    "version": "2.12.7",
     "description": "Calculs sur fichier corpus compressé",
     "repository": {
         "type": "git",

--- a/services/data-computer/swagger.json
+++ b/services/data-computer/swagger.json
@@ -15,7 +15,7 @@
             "x-comment": "Will be automatically completed by the ezs server."
         },
         {
-            "url": "http://vptdmjobs.intra.inist.fr:49175/",
+            "url": "http://vptdmjobs.intra.inist.fr:49187/",
             "description": "Latest version for production",
             "x-profil": "Standard"
         }

--- a/services/data-computer/swagger.json
+++ b/services/data-computer/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "data-computer - Calculs sur fichier corpus compressé",
         "summary": "Calculs sur un corpus compressé",
-        "version": "2.12.7",
+        "version": "2.12.8",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/services/data-computer/swagger.json
+++ b/services/data-computer/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "data-computer - Calculs sur fichier corpus compressé",
         "summary": "Calculs sur un corpus compressé",
-        "version": "2.12.6",
+        "version": "2.12.7",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",


### PR DESCRIPTION
Instead of specifying older ones.
Historically it may have been done to use newer versions, but it is no more the case.