### PR TITLE
[loterre-resolvers]: Move databases into /app/public

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4481,7 +4481,7 @@
         },
         "services/biblio-tools": {
             "name": "ws-biblio-tools",
-            "version": "4.1.0",
+            "version": "4.2.0",
             "license": "MIT"
         },
         "services/chem-ner": {
@@ -4546,7 +4546,7 @@
         },
         "services/loterre-resolvers": {
             "name": "ws-loterre-resolvers",
-            "version": "7.0.3",
+            "version": "7.0.4",
             "license": "MIT"
         },
         "services/ner-tagger": {

--- a/services/loterre-resolvers/README.md
+++ b/services/loterre-resolvers/README.md
@@ -1,4 +1,4 @@
-# ws-loterre-resolvers@7.0.3
+# ws-loterre-resolvers@7.0.4
 
 Résolveurs pour des terminologies Loterre
 

--- a/services/loterre-resolvers/docker-entrypoint.sh
+++ b/services/loterre-resolvers/docker-entrypoint.sh
@@ -4,13 +4,13 @@
 find /app/public ! -user daemon -exec chown daemon:daemon {} \;
 find /tmp ! -user daemon -exec chown daemon:daemon {} \;
 
-cd /tmp || exit 1
-for tgz in /app/data/*.tgz; do su -s /bin/bash daemon -c "tar -xf $tgz"; done
-
-cd /app || exit 2
+cd /app || exit 1
 node generate-dotenv.js
 
-cd /app/public || exit 3
+cd /app/public || exit 2
+
+# Restore databases
+for tgz in /app/data/*.tgz; do su -s /bin/bash daemon -c "tar -xf $tgz"; done
 
 # Run ezs server as daemon user
 su -s /bin/bash daemon -c "npx dotenv -e ../.env -- npx ezs --daemon ./"

--- a/services/loterre-resolvers/package.json
+++ b/services/loterre-resolvers/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-loterre-resolvers",
-    "version": "7.0.3",
+    "version": "7.0.4",
     "description": "Résolveurs pour des terminologies Loterre",
     "repository": {
         "type": "git",

--- a/services/loterre-resolvers/swagger.json
+++ b/services/loterre-resolvers/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "loterre-resolvers - Résolveurs pour des terminologies Loterre",
         "summary": "Fait appel aux vocabulaires Loterre pour obtenir des informations dans différents domaines.",
-        "version": "7.0.3",
+        "version": "7.0.4",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/services/loterre-resolvers/swagger.json
+++ b/services/loterre-resolvers/swagger.json
@@ -15,7 +15,7 @@
             "x-comment": "Will be automatically completed by the ezs server."
         },
         {
-            "url": "http://vptermsuite.intra.inist.fr:49171/",
+            "url": "http://vptermsuite.intra.inist.fr:49172/",
             "description": "Latest version for production",
             "x-profil": "Standard"
         }

--- a/services/loterre-resolvers/v1/combine.cfg
+++ b/services/loterre-resolvers/v1/combine.cfg
@@ -1,7 +1,7 @@
 # Configuration du chemin de stockage des bases des données locales
 [env]
 path = location
-value = fix(`${env('TMPDIR', '/tmp')}/databases/${env('loterreID', 'noid')}`)
+value = fix(`/app/public/databases/${env('loterreID', 'noid')}`)
 
 # STEP 0 : On normalise la valeur à rechercher (de la même manière que l'index a été créé)
 [assign]
@@ -24,7 +24,7 @@ value = get('id')
 path = value
 value = get('result.value', 'n/a')
 
-# STEP 1 : si l'index inversé nous donne une URI, avec on va chercher les informations associées
+# STEP 1 : si l'index inversé nous donne une URI, on va chercher les informations associées
 [expand]
 path = value
 file = ./v1/transcribe.cfg


### PR DESCRIPTION
Because in /tmp they were removed automatically by cleanup scripts (only on production machines).