### PR TITLE
[hurl] update to version 5

### DIFF
--- a/.github/workflows/test-and-publish-on-tag.yml
+++ b/.github/workflows/test-and-publish-on-tag.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Install Hurl
         run: |
-          curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/4.3.0/hurl_4.3.0_amd64.deb
-          sudo dpkg -i hurl_4.3.0_amd64.deb
+          curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/5.0.1/hurl_5.0.1_amd64.deb
+          sudo dpkg -i hurl_5.0.1_amd64.deb
           hurl --version
 
       - name: Build .env from Github Actions secrets

--- a/.github/workflows/test-on-branch.yml
+++ b/.github/workflows/test-on-branch.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Install Hurl
         run: |
-          curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/4.3.0/hurl_4.3.0_amd64.deb
-          sudo dpkg -i hurl_4.3.0_amd64.deb
+          curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/5.0.1/hurl_5.0.1_amd64.deb
+          sudo dpkg -i hurl_5.0.1_amd64.deb
           hurl --version
 
       - name: Build .env from Github Actions secrets

--- a/bin/build-and-test.sh
+++ b/bin/build-and-test.sh
@@ -23,7 +23,7 @@ echo "Waiting server to be ready"
 wait_for_url "http://localhost:31976" 10 30000
 
 echo "Running hurl tests"
-hurl --variable host=http://localhost:31976 --test tests.hurl
+hurl --jobs 1 --variable host=http://localhost:31976 --test tests.hurl
 
 echo "Stopping container of $SERVICE_NAME"
 npm run stop:dev

--- a/bin/generate-example-tests.mjs
+++ b/bin/generate-example-tests.mjs
@@ -4,10 +4,10 @@
 // and for remote tests (services/<instance>/tests.hurl)
 //
 // To test locally, use:
-// hurl --test --variable host=http://localhost:31976 services/<instance>/tests.hurl
+// hurl --test --variable host=http://localhost:31976 --jobs 1 services/<instance>/tests.hurl
 //
 // To test remotely, use:
-// hurl --test --variable host=https://<instance>.services.istex.fr services/<instance>/tests.hurl
+// hurl --test --variable host=https://<instance>.services.istex.fr --jobs 1 services/<instance>/tests.hurl
 //
 // The service should be launched as a local server. URL: http://localhost:31976
 // Just launch:

--- a/bin/test-ip-services.sh
+++ b/bin/test-ip-services.sh
@@ -18,7 +18,7 @@ for SERVICE in "${SERVICES[@]}"; do
 
     SERVICE_LOCAL_URL=$(jq -r '.servers[1].url' "services/$SERVICE/swagger.json")
     SERVICE_LOCAL_IP=$(echo "$SERVICE_LOCAL_URL" | sed -e 's|vptdmservices.intra.inist.fr|192.168.128.151|' -e 's|vptdmjobs.intra.inist.fr|192.168.128.74|')
-    npx hurl --test --continue-on-error --variable host="$SERVICE_LOCAL_IP" "services/$SERVICE/tests.hurl"
+    npx hurl --jobs 1 --test --continue-on-error --variable host="$SERVICE_LOCAL_IP" "services/$SERVICE/tests.hurl"
 done
 
 exit 0

--- a/bin/test-on-branch.sh
+++ b/bin/test-on-branch.sh
@@ -22,7 +22,7 @@ echo "Waiting server to be ready"
 wait_for_url "http://localhost:31976" 10 30000
 
 echo "Running hurl tests"
-hurl --variable host=http://localhost:31976 --test tests.hurl
+hurl --jobs 1 --variable host=http://localhost:31976 --test tests.hurl
 
 echo "Stopping container of $SERVICE_NAME"
 npm run stop:dev

--- a/bin/test-on-tag.sh
+++ b/bin/test-on-tag.sh
@@ -27,7 +27,7 @@ echo "Waiting server to be ready"
 wait_for_url "http://localhost:31976" 10 30000
 
 echo "Running hurl tests"
-hurl --variable host=http://localhost:31976 --test tests.hurl
+hurl --variable host=http://localhost:31976 --test --jobs 1 tests.hurl
 
 echo "Stopping container of $SERVICE_NAME"
 npm run stop:dev

--- a/bin/test-service.sh
+++ b/bin/test-service.sh
@@ -31,4 +31,4 @@ else
     HOST="https://$SERVICE.services.istex.fr"
 fi
 
-npx hurl --test --variable host="$HOST" "services/$SERVICE/tests.hurl"
+npx hurl --test --jobs 1 --variable host="$HOST" "services/$SERVICE/tests.hurl"

--- a/bin/test-services-tsv.sh
+++ b/bin/test-services-tsv.sh
@@ -21,7 +21,7 @@ for SERVICE in "${SERVICES[@]}"; do
         continue
     fi
 
-    npx hurl --test --continue-on-error --variable host="https://$SERVICE.services.istex.fr" "services/$SERVICE/tests.hurl" 2> /dev/null
+    npx hurl --test --jobs 1 --continue-on-error --variable host="https://$SERVICE.services.istex.fr" "services/$SERVICE/tests.hurl" 2> /dev/null
     if [ $? -ne 0 ]; then
         printf "%s\t%s\t❌\n" "$SERVICE" "$VERSION"
     else

--- a/bin/test-services.sh
+++ b/bin/test-services.sh
@@ -16,7 +16,7 @@ for SERVICE in "${SERVICES[@]}"; do
         continue
     fi
 
-    npx hurl --test --continue-on-error --variable host="https://$SERVICE.services.istex.fr" "services/$SERVICE/tests.hurl"
+    npx hurl --test --jobs 1 --continue-on-error --variable host="https://$SERVICE.services.istex.fr" "services/$SERVICE/tests.hurl"
 done
 
 exit 0

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@ezs/basics": "2.7.0",
     "@ezs/core": "3.10.2",
     "@ezs/spawn": "1.4.6",
-    "@orangeopensource/hurl": "4.3.2",
+    "@orangeopensource/hurl": "5.0.1",
     "rest-cli": "1.8.13"
   },
   "devDependencies": {


### PR DESCRIPTION
Version 5 of hurl provide better error messages, which would be profitable while writing tests and understanding error messages of daily tests.

> [!WARNING]
> Tests are now executed in parallel, use `--jobs 1` option to avoid that.

> [!NOTE]
> Don't forget [daily tests](https://vegitlab.intra.inist.fr/tdm/ws-cron-testing).