### PR TITLE
[loterre resolvers] fix swagger perf

### DIFF
--- a/services/loterre-resolvers/Dockerfile
+++ b/services/loterre-resolvers/Dockerfile
@@ -25,8 +25,11 @@ WORKDIR /app/public
 
 # Install all node dependencies
 RUN npm install \
-    @ezs/storage@3.2.3 \
-    @ezs/xslt@1.3.31
+    @ezs/core@3.10.9 \
+    @ezs/analytics@2.3.4 \
+    @ezs/basics@2.8.1 \
+    @ezs/storage@3.2.5 \
+    @ezs/xslt@1.3.32
 
 # Declare files to copy in .dockerignore
 COPY --chown=daemon:daemon --from=dvcfiles /dvc/*.skos /app/data/

--- a/services/loterre-resolvers/README.md
+++ b/services/loterre-resolvers/README.md
@@ -1,4 +1,4 @@
-# ws-loterre-resolvers@7.0.4
+# ws-loterre-resolvers@7.0.5
 
 Résolveurs pour des terminologies Loterre
 

--- a/services/loterre-resolvers/docker-entrypoint.sh
+++ b/services/loterre-resolvers/docker-entrypoint.sh
@@ -11,6 +11,7 @@ cd /app/public || exit 2
 
 # Restore databases
 for tgz in /app/data/*.tgz; do su -s /bin/bash daemon -c "tar -xf $tgz"; done
+mv /app/public/databases /app/public/.databases
 
 # Run ezs server as daemon user
 su -s /bin/bash daemon -c "npx dotenv -e ../.env -- npx ezs --daemon ./"

--- a/services/loterre-resolvers/package.json
+++ b/services/loterre-resolvers/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-loterre-resolvers",
-    "version": "7.0.4",
+    "version": "7.0.5",
     "description": "Résolveurs pour des terminologies Loterre",
     "repository": {
         "type": "git",

--- a/services/loterre-resolvers/swagger.json
+++ b/services/loterre-resolvers/swagger.json
@@ -15,7 +15,7 @@
             "x-comment": "Will be automatically completed by the ezs server."
         },
         {
-            "url": "http://vptermsuite.intra.inist.fr:49172/",
+            "url": "http://vptermsuite.intra.inist.fr:49173/",
             "description": "Latest version for production",
             "x-profil": "Standard"
         }

--- a/services/loterre-resolvers/swagger.json
+++ b/services/loterre-resolvers/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "loterre-resolvers - Résolveurs pour des terminologies Loterre",
         "summary": "Fait appel aux vocabulaires Loterre pour obtenir des informations dans différents domaines.",
-        "version": "7.0.4",
+        "version": "7.0.5",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/services/loterre-resolvers/v1/combine.cfg
+++ b/services/loterre-resolvers/v1/combine.cfg
@@ -1,7 +1,7 @@
 # Configuration du chemin de stockage des bases des données locales
 [env]
 path = location
-value = fix(`/app/public/databases/${env('loterreID', 'noid')}`)
+value = fix(`/app/public/.databases/${env('loterreID', 'noid')}`)
 
 # STEP 0 : On normalise la valeur à rechercher (de la même manière que l'index a été créé)
 [assign]


### PR DESCRIPTION
A new version of `@ezs/core` was done to avoid the swagger performance struggle when numerous files were present at the server's root directory (for `loterre-resolvers`, there is roughly 2 millions files, taking 1 minute to be scanned to build `swagger.json`).

Inist-CNRS/ezs#430

Let's make a `loterre-resolvers` version using that new version of `@ezs/core`.