### PR TITLE
[tests] desactivate blocked tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,6 +254,17 @@ On peut aussi [tester le serveur local](#tests).
 
 > 📘 On peut aussi écrire ce fichier à la main, voir [hurl](https://hurl.dev/).
 
+> [!TIP]  
+> Lorsque le test ne passe pas sur GitHub, parce que la route en question
+> utilise une API vérifiant l'IP de l'appelant, on peut se contenter de
+> désactiver ce test en fonction d'une variable `blocked` (qui sera
+> automatiquement positionnée à `true` sur GitHub).  
+>
+> ```ini
+> [Options]
+> skip: {{blocked}}
+> ```
+
 ### Script d'initialisation d'un nouveau service
 
 Pour faciliter la création d'un nouveau service, un script npm est disponible:
@@ -422,27 +433,27 @@ docker stop dev
 Pour tester un service lancé localement, utiliser:
 
 ```bash
-npm run test:local service-name
+HURL_blocked=false npm run test:local service-name
 ```
 
 Pour tester un service en production, taper:
 
 ```bash
-npm run test:remote service-name
+HURL_blocked=false npm run test:remote service-name
 ```
 
 Pour tester tous les services en production qui ont un fichier
 `tests.hurl`:
 
 ```bash
-npm run test:remotes services/*
+HURL_blocked=false npm run test:remotes services/*
 ```
 
 Pour tester uniquement certains services en production (à condition qu'ils aient
 un fichier `tests.hurl`):
 
 ```bash
-npm run test:remotes service-name service2-name
+HURL_blocked=false npm run test:remotes service-name service2-name
 ```
 
 > 📘 Pour éviter qu'un service soit testé lorsqu'il est en production, on peut
@@ -460,6 +471,19 @@ publié (sans URL externe), en se basant sur l'URL présente dans `swagger.json`
 ```bash
 ./bin/test-ip-services.sh services/service-name/
 ```
+
+> [!IMPORTANT]  
+> La partie `HURL_blocked=false` permet de préciser qu'on veut lancer *tous* les
+> tests du fichier `tests.hurl` concerné.  
+> Cette variable d'environnement est là pour permettre de lancer les tests d'un
+> fichier `tests.hurl` tout en ignorant ceux qui nécessitent un accès aux
+> services ISTEX.  
+> C'est le cas quand un GitHub Action essaye de lancer les tests: son IP n'est
+> pas présente dans les IP autorisées à accéder aux services ISTEX en
+> production.  
+> Dans ce cas, ou quand l'ordinateur depuis lequel on veut lancer les tests n'a
+> pas d'IP autorisée (par exemple chez soi, sans le VPN), on doit positionner la
+> variable `HURL_blocked` à `true`.  
 
 ## Ajout dans la liste du README
 

--- a/bin/test-ip-services.sh
+++ b/bin/test-ip-services.sh
@@ -18,7 +18,7 @@ for SERVICE in "${SERVICES[@]}"; do
 
     SERVICE_LOCAL_URL=$(jq -r '.servers[1].url' "services/$SERVICE/swagger.json")
     SERVICE_LOCAL_IP=$(echo "$SERVICE_LOCAL_URL" | sed -e 's|vptdmservices.intra.inist.fr|192.168.128.151|' -e 's|vptdmjobs.intra.inist.fr|192.168.128.74|')
-    npx hurl --jobs 1 --test --continue-on-error --variable host="$SERVICE_LOCAL_IP" "services/$SERVICE/tests.hurl"
+    npx hurl --jobs 1 --test --continue-on-error --variable host="$SERVICE_LOCAL_IP" --variable blocked=false "services/$SERVICE/tests.hurl"
 done
 
 exit 0

--- a/bin/test-on-branch.sh
+++ b/bin/test-on-branch.sh
@@ -22,7 +22,7 @@ echo "Waiting server to be ready"
 wait_for_url "http://localhost:31976" 10 30000
 
 echo "Running hurl tests"
-hurl --jobs 1 --variable host=http://localhost:31976 --test tests.hurl
+hurl --jobs 1 --variable host=http://localhost:31976 --variable blocked=true --test tests.hurl
 
 echo "Stopping container of $SERVICE_NAME"
 npm run stop:dev

--- a/bin/test-on-tag.sh
+++ b/bin/test-on-tag.sh
@@ -27,7 +27,7 @@ echo "Waiting server to be ready"
 wait_for_url "http://localhost:31976" 10 30000
 
 echo "Running hurl tests"
-hurl --variable host=http://localhost:31976 --test --jobs 1 tests.hurl
+hurl --variable host=http://localhost:31976 --variable block=true --test --jobs 1 tests.hurl
 
 echo "Stopping container of $SERVICE_NAME"
 npm run stop:dev

--- a/services/affiliations-tools/tests.hurl
+++ b/services/affiliations-tools/tests.hurl
@@ -1,7 +1,7 @@
 POST {{host}}/v1/expand?indent=true
 content-type: application/json
 [Options]
-skip: true
+skip: {{blocked}}
 [
   { "value": "Baran, N (reprint author), Univ Zagreb, Dept Phys, Bijenieka Cesta 32, Zagreb 10000, Croatia."},
   { "value": "Harikane, Y (reprint author), Univ Tokyo, Inst Cosm Ray Res, 5-1-5 Kashiwanoha, Kashiwa, Chiba 2778582, Japan.; Harikane, Y (reprint author), Univ Tokyo, Grad Sch Sci, Dept Phys, Bunkyo Ku, 7-3-1 Hongo, Tokyo 1130033, Japan."},


### PR DESCRIPTION
Voir #228

Certains tests doivent être désactivés dans certaines conditions: quand ils font appel à un autre web service du dépôt en production, et qu'ils sont lancés d'une IP non autorisée.

C'est pourquoi on utilise une variable `blocked` dans `tests.hurl` pour savoir si l'IP d'où on lance les tests est bloquée ou non.  
Ces cas devraient être relativement rares (seulement 8 recensés au 22 janvier 2025).  
