### PR TITLE
[loterre-resolvers] /app/data overwritten by Persistent Volume Claim

### DIFF
--- a/services/loterre-resolvers/Dockerfile
+++ b/services/loterre-resolvers/Dockerfile
@@ -32,9 +32,9 @@ RUN npm install \
     @ezs/xslt@1.3.32
 
 # Declare files to copy in .dockerignore
-COPY --chown=daemon:daemon --from=dvcfiles /dvc/*.skos /app/data/
-COPY --chown=daemon:daemon --from=dvcfiles /dvc/databases /app/data/
-RUN chmod a+rwx /app/data
+COPY --chown=daemon:daemon --from=dvcfiles /dvc/*.skos /app/data0/
+COPY --chown=daemon:daemon --from=dvcfiles /dvc/databases /app/data0/
+RUN chmod a+rwx /app/data0
 
 COPY --chown=daemon:daemon ./docker-entrypoint.sh /app/
 COPY --chown=daemon:daemon ./config.json /app/

--- a/services/loterre-resolvers/README.md
+++ b/services/loterre-resolvers/README.md
@@ -1,4 +1,4 @@
-# ws-loterre-resolvers@7.0.6
+# ws-loterre-resolvers@7.0.7
 
 Résolveurs pour des terminologies Loterre
 

--- a/services/loterre-resolvers/docker-entrypoint.sh
+++ b/services/loterre-resolvers/docker-entrypoint.sh
@@ -8,10 +8,16 @@ cd /app || exit 1
 node generate-dotenv.js
 
 
+mkdir -p /app/data
+chown -R daemon:daemon /app/data
+
+# Restore SKOS files
+cp /app/data0/*.skos /app/data
+
 # Restore databases
 cd /app/data || exit 2
 
-for tgz in /app/data/*.tgz
+for tgz in /app/data0/*.tgz
 do
     su -s /bin/bash daemon -c "tar -xf $tgz"
     echo "Extracted $tgz"

--- a/services/loterre-resolvers/package.json
+++ b/services/loterre-resolvers/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-loterre-resolvers",
-    "version": "7.0.6",
+    "version": "7.0.7",
     "description": "Résolveurs pour des terminologies Loterre",
     "repository": {
         "type": "git",

--- a/services/loterre-resolvers/swagger.json
+++ b/services/loterre-resolvers/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "loterre-resolvers - Résolveurs pour des terminologies Loterre",
         "summary": "Fait appel aux vocabulaires Loterre pour obtenir des informations dans différents domaines.",
-        "version": "7.0.6",
+        "version": "7.0.7",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",


### PR DESCRIPTION
So we copy `.tgz` in `/app/data0` (during buit) before extracting them in `/app/data` (at run).

See https://github.com/Inist-CNRS/web-services/issues/194#issuecomment-2621729925