### PR TITLE
[Documentation IA Factory] : Homogénéisation des documentations des services dans IA Factory

### DIFF
--- a/services/biblio-ref/v1/validate-pdf.ini
+++ b/services/biblio-ref/v1/validate-pdf.ini
@@ -2,8 +2,8 @@
 mimeType = application/json
 
 post.operationId = post-v1-validate-pdf
-post.summary = Valide l'ensemble des références bibliographiques d'un PDF.
-post.description =  Trouve les références bibliographiques d'un PDF puis utilise crossref pour:^M- valider les références bibliographiques^M- donner les DOIs s'ils existent^M- indiquer les éventuelles références rétractées.
+post.summary = bibCheck - Contrôle de référence bibliographique.
+post.description =  Extrait les références bibliographiques d'un PDF puis utilise crossref pour:^M- valider les références, ^M- donner les DOIs s'ils existent, ^M- indiquer les éventuelles références rétractées. ^M L'entrée doit être un PDF et le "nom du champs à exploiter" ne doit pas être renseigné.
 post.tags.0 = biblio-ref
 post.requestBody.required = true
 post.responses.default.description = PDF au format PDF

--- a/services/data-computer/v1/lda.ini
+++ b/services/data-computer/v1/lda.ini
@@ -3,8 +3,8 @@ mimeType = application/json
 
 # OpenAPI Documentation - JSON format (dot notation)
 post.operationId = post-v1-lda
-post.summary = Extrait des thématiques d'un corpus.
-post.description = Crée à partir de l'ensemble des documents un champ `lda` constitué de plusieurs _topics_ eux-mêmes caractérisés par 10 mots.^M> **Note**: Le texte doit être en anglais.^M^M> **Note 2**: La qualité des résultats dépend du corpus et les _topics_ doivent être analysés par l'utilisateur avant d'être utilisés.
+post.summary = ldaClass - Extraction de thématiques d’un corpus.
+post.description = Extrait des thématiques d’un corpus de textes écrit en anglais. Une thématique (ou topic) est caractérisée par un ensemble de mots. Une fois les thématiques extraites, chaque document se voit attribuer une ou plusieurs thématique(s).
 post.tags.0 = data-computer
 post.requestBody.content.application/x-gzip.schema.type = string
 post.requestBody.content.application/x-gzip.schema.format = binary

--- a/services/data-computer/v1/lda.ini
+++ b/services/data-computer/v1/lda.ini
@@ -4,7 +4,7 @@ mimeType = application/json
 # OpenAPI Documentation - JSON format (dot notation)
 post.operationId = post-v1-lda
 post.summary = ldaClass - Extraction de thématiques d’un corpus.
-post.description = Extrait des thématiques d’un corpus de textes écrit en anglais. Une thématique (ou topic) est caractérisée par un ensemble de mots. Une fois les thématiques extraites, chaque document se voit attribuer une ou plusieurs thématique(s).
+post.description = Extrait des thématiques d’un corpus de textes écrit en anglais. Une thématique (ou topic) est caractérisée par un ensemble de mots. Une fois les thématiques extraites, chaque document se voit attribuer une ou plusieurs thématique(s). ^M L'entrée doit être un CSV et la colonne contenant les textes à traiter doit être spécifiée dans "nom du champs à exploiter".
 post.tags.0 = data-computer
 post.requestBody.content.application/x-gzip.schema.type = string
 post.requestBody.content.application/x-gzip.schema.format = binary

--- a/services/data-topcitation/v1/topcitation.ini
+++ b/services/data-topcitation/v1/topcitation.ini
@@ -3,8 +3,8 @@ mimeType = application/json
 
 # OpenAPI Documentation - JSON format (dot notation)
 post.operationId = post-v1-topcitation
-post.summary = Extraction des références phares
-post.description = A partir d'une liste de DOI récupère les 10 références phares du corpus
+post.summary = topRefExtract - Extraction des références phares d’un corpus.
+post.description = Ce web service identifie les 10 publications les plus citées dans un corpus donné. ^M L'entrée doit être un CSV et la colonne contenant les liste de DOIs à traiter doit être spécifiée dans "nom du champs à exploiter".
 post.tags.0 = data-topcitation
 post.requestBody.content.application/x-gzip.schema.type = string
 post.requestBody.content.application/x-gzip.schema.format = binary

--- a/services/data-workflow/v1/pdf-text.ini
+++ b/services/data-workflow/v1/pdf-text.ini
@@ -3,8 +3,8 @@ mimeType = application/json
 
 # OpenAPI Documentation - JSON format (dot notation)
 post.operationId = post-v1-pdf-text
-post.summary = Extrait le texte d'un fichier PDF
-post.description = Transforme un fichier type PDF en texte nettoyé.
+post.summary = textExtract - Extraction du texte à partir d’un PDF
+post.description = Transforme un fichier type PDF en texte nettoyé. ^M L'entrée doit être un PDF et le "nom du champs à exploiter" ne doit pas être renseigné.
 post.tags.0 = pdf-text
 post.requestBody.content.application/x-gzip.schema.type = string
 post.requestBody.content.application/x-gzip.schema.format = binary

--- a/services/data-workflow/v1/tag-cloud-en.ini
+++ b/services/data-workflow/v1/tag-cloud-en.ini
@@ -3,8 +3,8 @@ mimeType = application/json
 
 # OpenAPI Documentation - JSON format (dot notation)
 post.operationId = post-v1-tag-cloud-en
-post.summary = Le résultat produit une liste de termes associés à leurs fréquences
-post.description = Chargement et analyse d'un fichier corpus pour compter le nombre de termes *anglais* pertinents identiques dans chaque document
+post.summary = Teeft - Extraction de termes d’un corpus de textes en anglais.
+post.description = Extrait les termes les plus spécifiques d’un ensemble de textes en anglais. ^M L'entrée doit être un CSV et la colonne contenant les textes à traiter doit être spécifiée dans "nom du champs à exploiter". 
 post.tags.0 = tag-cloud
 post.requestBody.content.application/x-gzip.schema.type = string
 post.requestBody.content.application/x-gzip.schema.format = binary

--- a/services/data-workflow/v1/tag-cloud-fr.ini
+++ b/services/data-workflow/v1/tag-cloud-fr.ini
@@ -3,8 +3,8 @@ mimeType = application/json
 
 # OpenAPI Documentation - JSON format (dot notation)
 post.operationId = post-v1-tag-cloud-fr
-post.summary = Le résultat produit une liste de termes associés à leurs fréquences
-post.description = Chargement et analyse d'un fichier corpus pour compter le nombre de termes *français* pertinents identiques dans chaque document
+post.summary = Teeft - Extraction de termes d’un corpus de textes en français.
+post.description = Extrait les termes les plus spécifiques d’un ensemble de textes en français. ^M L'entrée doit être un CSV et la colonne contenant les textes à traiter doit être spécifiée dans "nom du champs à exploiter". 
 post.tags.0 = tag-cloud
 post.requestBody.content.application/x-gzip.schema.type = string
 post.requestBody.content.application/x-gzip.schema.format = binary

--- a/services/sciencemetrix-classification/v1/classif.ini
+++ b/services/sciencemetrix-classification/v1/classif.ini
@@ -1,8 +1,8 @@
 # OpenAPI Documentation - JSON format (dot notation)
 mimeType = application/json
 
-post.summary = Classification en domaines scientifiques Science-Metrix
-post.description = Le web service classe automatiquement des documents scientifiques en anglais dans le troisième niveau de la classification Science-Metrix à partir de leur résumé. Attention : si les résumés sont trop courts, le risque d'erreur est augmenté.
+post.summary = sciencemetrixClass - Classification en domaines scientifiques Science-Metrix.
+post.description = Le web service classe automatiquement des documents scientifiques en anglais dans le troisième niveau de la classification Science-Metrix à partir de leur résumé. ^M L'entrée doit être un CSV et la colonne contenant les textes à traiter doit être spécifiée dans "nom du champs à exploiter". 
 post.responses.default.content.application/json.schema.$ref =  #/components/schemas/JSONStream
 post.tags.0 = sciencemetrix-classification
 post.requestBody.required = true

--- a/services/text-clustering/v1/clustering.ini
+++ b/services/text-clustering/v1/clustering.ini
@@ -3,8 +3,8 @@ mimeType = application/json
 
 # OpenAPI Documentation - JSON format (dot notation)
 post.operationId = post-v1-clustering
-post.summary = Crée différents `clusters` à partir d'un ensemble de textes courts ou d'un ensemble de listes de mots-clés.
-post.description = Crée plusieurs groupe afin d'y classifier les différents textes en fonction de leur similarité.^M> - Le nombre de `cluster` est déterminé de manière automatique et des documents peuvent être considérés comme du bruit (dans ce cas précis, le label de leur cluster sera `0` ; les documents appartenant du cluster 0 ne sont pas regroupés ensembles).^M^M> - L'entrée peut être un texte court (type titre ou petit abstract), mais aussi une liste de mots-clés.
+post.summary = textClustering - Extraction de clusters d’un corpus.
+post.description = L’algorithme extrait plusieurs groupes (clusters) d’un corpus afin d’y classer les différents textes en fonction de leur similarité. Un document est présent dans un seul groupe. Chaque cluster est caractérisé par maximum 20 termes. ^M> - Le nombre de `cluster` est déterminé de manière automatique. ^M^M> - Les objets à traiter doivent être en anglais et peuvent être des textes courts (type titres ou petits abstracts) ou des listes de mots-clés. ^M L'entrée doit être un CSV et la colonne contenant les textes à traiter doit être spécifiée dans "nom du champs à exploiter". 
 post.tags.0 = clustering
 post.requestBody.content.application/x-gzip.schema.type = string
 post.requestBody.content.application/x-gzip.schema.format = binary

--- a/services/text-clustering/v1/noise.ini
+++ b/services/text-clustering/v1/noise.ini
@@ -3,8 +3,8 @@ mimeType = application/json
 
 # OpenAPI Documentation - JSON format (dot notation)
 post.operationId = post-v1-noise
-post.summary = Dans un corpus, retourne la liste des identifiants des documents considérés comme du bruit.
-post.description = Utilise l'algorithme de *clustering* et retourne uniquement la liste des identifiants considérés comme du bruit par [HDBSCAN](https://hdbscan.readthedocs.io/en/latest/how_hdbscan_works.html).
+post.summary = noiseDetect - Détection de bruit d’un corpus.
+post.description = L’algorithme repère la liste des identifiants des documents considérés comme du bruit dans un corpus. Il s’agit de documents considérés comme non pertinents. Les objets à traiter doivent être en anglais et peuvent être des textes courts (type titres ou petits abstracts) ou des listes de mots-clés. ^M L'entrée doit être un CSV et la colonne contenant les textes à traiter doit être spécifiée dans "nom du champs à exploiter".
 post.tags.0 = clustering
 post.requestBody.content.application/x-gzip.schema.type = string
 post.requestBody.content.application/x-gzip.schema.format = binary


### PR DESCRIPTION
Pour l'ensemble des services pour l'instant, je prend comme affichage "nomCourt - Titre du service dans Istex TDM".
Pour la description je prend la description du service dans IA Factory (et essaye de l'adapter le moins possible).

Liste des services fait :
- [ ] **/v1/corpus-similarity**: pas de page Istex TDM ?
- [ ] **/v1/group-by** :  à supprimer de IA Factory ?
- [x] **/v1/lda**
- [ ] **/v1/retrieve-statut** : à supprimer de IA Factory ?
- [ ] **/v1/en** : Ne garder qu'une route sur les deux pour Termsuite ? Ou non ?
- [ ] **/v1/fr** : Ne garder qu'une route sur les deux pour Termsuite ? Ou non ?
- [ ] **/v1/en/minimal** : Ne garder qu'une route sur les deux pour Termsuite ? Ou non ?
- [ ] **/v1/fr/minimal** : Ne garder qu'une route sur les deux pour Termsuite ? Ou non ?
- [x] **/v1/noise**
- [x] **/v1/clustering**
- [x] **/v1/topcitation**
- [ ] **/v1/sudoc**: à supprimer de IA Factory ?
- [ ] **/v1/baseline**  : à supprimer de IA Factory ?
- [ ] **/v1/rapido-algorithme** : pas de fiche ISTEX TDM.
- [ ] **/v1/rapido-apprentissage** : pas de fiche ISTEX TDM.
- [x] **/v1/bibcheck-pdf**
- [x] **/v1/sciencemetrix-class**
- [x] **/v1/tag-cloud-en** 
- [x] **/v1/tag-cloud-fr**
- [x] **/v1/pdf-text**