### PR TITLE
[text clustering] fix a bug on small corpus

### DIFF
--- a/bin/test-on-tag.sh
+++ b/bin/test-on-tag.sh
@@ -27,7 +27,7 @@ echo "Waiting server to be ready"
 wait_for_url "http://localhost:31976" 10 30000
 
 echo "Running hurl tests"
-hurl --variable host=http://localhost:31976 --variable block=true --test --jobs 1 tests.hurl
+hurl --variable host=http://localhost:31976 --variable blocked=true --test --jobs 1 tests.hurl
 
 echo "Stopping container of $SERVICE_NAME"
 npm run stop:dev

--- a/services/text-clustering/README.md
+++ b/services/text-clustering/README.md
@@ -1,4 +1,4 @@
-# ws-text-clustering@1.4.2
+# ws-text-clustering@1.4.3
 
 Crée différents *clusters* à partir d'un ensemble de textes courts ou d'un ensemble de listes de mots-clés. Ce web service est asynchrone et traite des corpus et non des documents.
 

--- a/services/text-clustering/README.md
+++ b/services/text-clustering/README.md
@@ -1,4 +1,4 @@
-# ws-text-clustering@1.4.1
+# ws-text-clustering@1.4.2
 
 Crée différents *clusters* à partir d'un ensemble de textes courts ou d'un ensemble de listes de mots-clés. Ce web service est asynchrone et traite des corpus et non des documents.
 

--- a/services/text-clustering/package.json
+++ b/services/text-clustering/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-text-clustering",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "description": "Créer différents `clusters` à partir d'un ensemble de textes courts ou d'un ensemble de listes de mots-clés.",
     "repository": {
         "type": "git",

--- a/services/text-clustering/package.json
+++ b/services/text-clustering/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-text-clustering",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "Créer différents `clusters` à partir d'un ensemble de textes courts ou d'un ensemble de listes de mots-clés.",
     "repository": {
         "type": "git",

--- a/services/text-clustering/swagger.json
+++ b/services/text-clustering/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "text-clustering - Crée différents clusters à partir d'un ensemble de textes courts ou d'un ensemble de listes de mots-clés.",
         "description": "Crée plusieurs groupe afin d'y classifier les différents textes en fonction de leur similarité. Le nombre de clusters est déterminé de manière automatique et des documents peuvent être considérés comme du bruit (dans ce cas précis, le label de leur cluster sera 0 ; les documents appartenant au cluster 0 ne sont pas regroupés ensembles). L'entrée peut être un texte court (type titre ou petit abstract), mais aussi une liste de mots-clés.",
-        "version": "1.4.1",
+        "version": "1.4.2",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/services/text-clustering/swagger.json
+++ b/services/text-clustering/swagger.json
@@ -15,7 +15,7 @@
             "x-comment": "Will be automatically completed by the ezs server."
         },
         {
-            "url": "http://vptdmjobs.intra.inist.fr:49205/",
+            "url": "http://vptdmjobs.intra.inist.fr:49216/",
             "description": "Latest version for production",
             "x-profil": "Standard"
         }

--- a/services/text-clustering/swagger.json
+++ b/services/text-clustering/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "text-clustering - Crée différents clusters à partir d'un ensemble de textes courts ou d'un ensemble de listes de mots-clés.",
         "description": "Crée plusieurs groupe afin d'y classifier les différents textes en fonction de leur similarité. Le nombre de clusters est déterminé de manière automatique et des documents peuvent être considérés comme du bruit (dans ce cas précis, le label de leur cluster sera 0 ; les documents appartenant au cluster 0 ne sont pas regroupés ensembles). L'entrée peut être un texte court (type titre ou petit abstract), mais aussi une liste de mots-clés.",
-        "version": "1.4.2",
+        "version": "1.4.3",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/services/text-clustering/v1/clustering.py
+++ b/services/text-clustering/v1/clustering.py
@@ -133,7 +133,6 @@ for i in range(len_data):
     except:
         indice_out_cluster.append(i)
 
-
 # Dimension reduction
 umap_model = umap.UMAP(
     n_neighbors=max(10, min(30, int(len_data / 20))),
@@ -145,7 +144,7 @@ umap_model = umap.UMAP(
 reduced_embeddings = umap_model.fit_transform(texts)
 
 if nb_cluster == 0:
-    nb_cluster = find_optimal_k(reduced_embeddings, max_k=30)
+    nb_cluster = find_optimal_k(reduced_embeddings, max_k=min(30, len(texts)-2))
 
 # Clustering
 clusterer = KMeans(n_clusters=nb_cluster, random_state=42)


### PR DESCRIPTION
On small corpus (< 30), couldn't use auto clustering.
This patch is useful for tests (like in IA Factory)