### PR TITLE
[data-wrapper] fix tar txt2json

### DIFF
--- a/services/data-wrapper/tests.hurl
+++ b/services/data-wrapper/tests.hurl
@@ -84,6 +84,7 @@ file,texts.tar.gz;
 HTTP 200
 Content-type: application/gzip
 [Asserts]
-bytes count >= 485
-bytes count <= 500
+bytes count >= 480
+bytes count <= 485
 bytes startsWith hex,1f8b0800;
+bytes endsWith hex,00140000;

--- a/services/data-wrapper/v1/tar-txt2json.ini
+++ b/services/data-wrapper/v1/tar-txt2json.ini
@@ -26,10 +26,10 @@ compress = true
 json = false
 
 [replace]
-path = fileName
+path = id
 value = get('id').replace(".txt", ".json")
 
-path = fileContent
+path = value
 value = get('value')
 
 [TARDump]


### PR DESCRIPTION
Ce wrapper fournissait un fichier `.tar.gz` contenant des fichiers `json` dont les objets contenaient les champs `fileName` et `fileContent`, et non `id` et `value`.  

Ce qui ne convient pas aux web services asynchrones qui les prennent en entrée.