### PR TITLE
[data-wrapper] Add txt

### DIFF
--- a/services/data-wrapper/README.md
+++ b/services/data-wrapper/README.md
@@ -1,4 +1,4 @@
-# ws-data-wrapper@1.6.1
+# ws-data-wrapper@1.7.0
 
 Conversions en fichier corpus compressé
 

--- a/services/data-wrapper/package.json
+++ b/services/data-wrapper/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-data-wrapper",
-    "version": "1.6.1",
+    "version": "1.7.0",
     "description": "Conversions en fichier corpus compressé",
     "repository": {
         "type": "git",

--- a/services/data-wrapper/swagger.json
+++ b/services/data-wrapper/swagger.json
@@ -15,7 +15,7 @@
             "x-comment": "Will be automatically completed by the ezs server."
         },
         {
-            "url": "http://vptdmjobs.intra.inist.fr:49217/",
+            "url": "http://vptdmjobs.intra.inist.fr:49222/",
             "description": "Latest version for production",
             "x-profil": "Standard"
         }

--- a/services/data-wrapper/swagger.json
+++ b/services/data-wrapper/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "data-wrapper - Conversions en fichier corpus compressé",
         "summary": "Les fichiers corpus compressés sont compatibles avec tous les traitements TDM dédiés aux corpus (services web asynchrone)",
-        "version": "1.6.1",
+        "version": "1.7.0",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/services/data-wrapper/tests.hurl
+++ b/services/data-wrapper/tests.hurl
@@ -88,3 +88,22 @@ bytes count >= 480
 bytes count <= 495
 bytes startsWith hex,1f8b0800;
 bytes endsWith hex,00140000;
+
+##########################################
+
+POST {{host}}/v1/txt
+content-type: text/plain
+```
+Ici je mets un texte quelconque.
+Sur plusieurs lignes.
+
+Avec des paragraphes séparés.
+```
+
+HTTP 200
+Content-type: application/gzip
+[Asserts]
+bytes count >= 370
+bytes count <= 395
+bytes startsWith hex,1f8b0800;
+bytes endsWith hex,000c0000;

--- a/services/data-wrapper/v1/csv.ini
+++ b/services/data-wrapper/v1/csv.ini
@@ -5,6 +5,7 @@ extension = tar.gz
 # OpenAPI Documentation - JSON format (dot notation)
 post.operationId = post-v1-csv
 post.summary = Transformation d'un fichier CSV en fichier corpus
+#'
 post.description = Le fichier est transformé en fichier corpus exploitable par un web service asynchrone
 post.tags.0 = data-wrapper
 post.requestBody.content.text/csv.schema.type = string

--- a/services/data-wrapper/v1/txt.ini
+++ b/services/data-wrapper/v1/txt.ini
@@ -1,0 +1,46 @@
+# Entrypoint output format
+mimeType = application/gzip
+extension = tar.gz
+
+# OpenAPI Documentation - JSON format (dot notation)
+post.operationId = post-v1-txt
+post.summary = Transformation d'un fichier texte en fichier corpus
+#'
+post.description = Le fichier est transformé en fichier corpus exploitable par un web service asynchrone
+post.tags.0 = data-wrapper
+post.requestBody.content.text/plain.schema.type = string
+post.requestBody.content.text/plain.schema.format = binary
+post.requestBody.required = true
+post.responses.default.description = Fichier corpus au format tar.gz
+post.responses.default.content.application/gzip.schema.type = string
+post.responses.default.content.application/gzip.schema.format = binary
+post.parameters.0.description = Identifiant à utiliser pour le document
+post.parameters.0.in = query
+post.parameters.0.name = id
+post.parameters.0.schema.type = string
+post.parameters.0.schema.default = text
+post.parameters.0.required = false
+
+[use]
+plugin = basics
+
+[TXTConcat]
+
+[replace]
+path = id
+value = env('id', 'text')
+path = value
+value = self()
+
+[singleton]
+[singleton/validate]
+path = value
+rule = required
+
+[TARDump]
+compress = true
+manifest = fix({version: '1'})
+manifest = fix({generator: 'v1/txt'})
+manifest = fix({parameters: _.omit(_.env(), 'headers')})
+manifest = fix({hostAgent: _.get(_.env(), 'headers.host')})
+manifest = fix({userAgent: _.get(_.env(), 'headers.user-agent')})


### PR DESCRIPTION
Add a wrapper that converts a text file to a corpus file (`.tar.gz` containing one JSON file with `id` and `value` fields, `value` containing the text).