### PR TITLE
[text clustering] fix noise detect output

### DIFF
--- a/services/text-clustering/README.md
+++ b/services/text-clustering/README.md
@@ -1,4 +1,4 @@
-# ws-text-clustering@1.4.6
+# ws-text-clustering@2.0.0
 
 Crée différents *clusters* à partir d'un ensemble de textes courts ou d'un ensemble de listes de mots-clés. Ce web service est asynchrone et traite des corpus et non des documents.
 

--- a/services/text-clustering/README.md
+++ b/services/text-clustering/README.md
@@ -1,4 +1,4 @@
-# ws-text-clustering@2.0.0
+# ws-text-clustering@2.0.1
 
 Crée différents *clusters* à partir d'un ensemble de textes courts ou d'un ensemble de listes de mots-clés. Ce web service est asynchrone et traite des corpus et non des documents.
 

--- a/services/text-clustering/package.json
+++ b/services/text-clustering/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-text-clustering",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Créer différents `clusters` à partir d'un ensemble de textes courts ou d'un ensemble de listes de mots-clés.",
     "repository": {
         "type": "git",

--- a/services/text-clustering/package.json
+++ b/services/text-clustering/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-text-clustering",
-    "version": "1.4.6",
+    "version": "2.0.0",
     "description": "Créer différents `clusters` à partir d'un ensemble de textes courts ou d'un ensemble de listes de mots-clés.",
     "repository": {
         "type": "git",

--- a/services/text-clustering/swagger.json
+++ b/services/text-clustering/swagger.json
@@ -15,7 +15,7 @@
             "x-comment": "Will be automatically completed by the ezs server."
         },
         {
-            "url": "http://vptdmjobs.intra.inist.fr:49228/",
+            "url": "http://vptdmjobs.intra.inist.fr:49234/",
             "description": "Latest version for production",
             "x-profil": "Standard"
         }

--- a/services/text-clustering/swagger.json
+++ b/services/text-clustering/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "text-clustering - Crée différents clusters à partir d'un ensemble de textes courts ou d'un ensemble de listes de mots-clés.",
         "description": "Crée plusieurs groupe afin d'y classifier les différents textes en fonction de leur similarité. Le nombre de clusters est déterminé de manière automatique et des documents peuvent être considérés comme du bruit (dans ce cas précis, le label de leur cluster sera 0 ; les documents appartenant au cluster 0 ne sont pas regroupés ensembles). L'entrée peut être un texte court (type titre ou petit abstract), mais aussi une liste de mots-clés.",
-        "version": "2.0.0",
+        "version": "2.0.1",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/services/text-clustering/swagger.json
+++ b/services/text-clustering/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "text-clustering - Crée différents clusters à partir d'un ensemble de textes courts ou d'un ensemble de listes de mots-clés.",
         "description": "Crée plusieurs groupe afin d'y classifier les différents textes en fonction de leur similarité. Le nombre de clusters est déterminé de manière automatique et des documents peuvent être considérés comme du bruit (dans ce cas précis, le label de leur cluster sera 0 ; les documents appartenant au cluster 0 ne sont pas regroupés ensembles). L'entrée peut être un texte court (type titre ou petit abstract), mais aussi une liste de mots-clés.",
-        "version": "1.4.6",
+        "version": "2.0.0",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/services/text-clustering/v1/noise-process.py
+++ b/services/text-clustering/v1/noise-process.py
@@ -14,7 +14,7 @@ for line in sys.stdin:
         continue
 
 # Did not success to do it in EZS
-# If no document are tag as noise, the stream is "break"
+# If no documents are tagged as noise, the stream is broken.
 # Can dodge it in python with the next line
 if len(output) == 0:
     sys.stdout.write(json.dumps({"noise": ""}))

--- a/services/text-clustering/v1/noise-process.py
+++ b/services/text-clustering/v1/noise-process.py
@@ -6,12 +6,19 @@ import json
 output = []
 
 for line in sys.stdin:
-    line=json.loads(line)
+    line = json.loads(line)
     try:
         if line["value"] == "noise":
-            output.append(line["id"])
-    except:
+            output.append({"noise": line["id"]})
+    except Exception:
         continue
 
-sys.stdout.write(json.dumps(output))
-sys.stdout.write("\n")
+# Did not success to do it in EZS
+# If no document are tag as noise, the stream is "break"
+# Can dodge it in python with the next line
+if len(output) == 0:
+    sys.stdout.write(json.dumps({"noise": ""}))
+else:
+    for elt in output:
+        sys.stdout.write(json.dumps(elt))
+        sys.stdout.write("\n")


### PR DESCRIPTION
I tried to use [swing] with ezs (instead of using another script with fork ; `noise-process.py`) but the streams is break when no noisy documents are returned