### PR TITLE
[data-wrapper] add default value to csv

### DIFF
--- a/services/data-wrapper/README.md
+++ b/services/data-wrapper/README.md
@@ -1,4 +1,4 @@
-# ws-data-wrapper@1.7.0
+# ws-data-wrapper@1.7.1
 
 Conversions en fichier corpus compressé
 

--- a/services/data-wrapper/package.json
+++ b/services/data-wrapper/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "ws-data-wrapper",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "Conversions en fichier corpus compressé",
     "repository": {
         "type": "git",

--- a/services/data-wrapper/swagger.json
+++ b/services/data-wrapper/swagger.json
@@ -15,7 +15,7 @@
             "x-comment": "Will be automatically completed by the ezs server."
         },
         {
-            "url": "http://vptdmjobs.intra.inist.fr:49222/",
+            "url": "http://vptdmjobs.intra.inist.fr:49232/",
             "description": "Latest version for production",
             "x-profil": "Standard"
         }

--- a/services/data-wrapper/swagger.json
+++ b/services/data-wrapper/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "data-wrapper - Conversions en fichier corpus compressé",
         "summary": "Les fichiers corpus compressés sont compatibles avec tous les traitements TDM dédiés aux corpus (services web asynchrone)",
-        "version": "1.7.0",
+        "version": "1.7.1",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/services/data-wrapper/tests.hurl
+++ b/services/data-wrapper/tests.hurl
@@ -48,6 +48,19 @@ HTTP 200
 
 ##########################################
 
+POST {{host}}/v1/csv?id=id&value=content
+content-type: text/csv
+```
+id,content
+1,
+2,Not empty
+```
+
+HTTP 200
+Content-type: application/gzip
+
+##########################################
+
 POST {{host}}/v1/tar-tei2json
 content-type: application/x-tar
 file,example-tei.tar.gz;

--- a/services/data-wrapper/v1/csv.ini
+++ b/services/data-wrapper/v1/csv.ini
@@ -53,6 +53,11 @@ value = get(env('value', 'value'))
 [exchange]
 value = self().thru(x => _.env(null, 'slim') ? _.pick(x, ['id', 'value']) : x)
 
+# Don't return empty values, so that validate doesn't fail
+[assign]
+path = value
+value = get('value').thru(v => v === '' ? 'n/a' : v)
+
 # in the hope that all the lines look the same
 [singleton]
 [singleton/validate]


### PR DESCRIPTION
When the first line of a CSV contains an empty value column, it isn't  validated.

So, the wrapper now replaces empty values with `"n/a"`.