### PR TITLE
[data-wrapper] Add fields/json & jsonl

### DIFF
--- a/services/data-wrapper/tests.hurl
+++ b/services/data-wrapper/tests.hurl
@@ -48,6 +48,40 @@ HTTP 200
 
 ##########################################
 
+POST {{host}}/v1/fields/json?indent=true
+content-type: application/json
+[
+    {"title": "Rocky", "actors": ["Sylvester Stallone", "Talia Shire", "Carl Weathers", "Burt Young"]},
+    {"title": "Rocky 2", "actors": ["Sylvester Stallone", "Talia Shire", "Carl Weathers", "Burt Young", "Burgess Meredith", "Tony Burton", "Frank Stallone", "Stu Nahan"]}
+]
+
+HTTP 200
+[{
+    "value": "title"
+},
+{
+    "value": "actors"
+}]
+
+##########################################
+
+POST {{host}}/v1/fields/jsonl?indent=true
+content-type: application/jsonl
+```
+{"title": "Rocky", "actors": ["Sylvester Stallone", "Talia Shire", "Carl Weathers", "Burt Young"]}
+```
+
+HTTP 200
+[{
+    "value": "title"
+},
+{
+    "value": "actors"
+}]
+
+
+##########################################
+
 POST {{host}}/v1/csv?id=id&value=content
 content-type: text/csv
 ```

--- a/services/data-wrapper/v1/fields/csv.ini
+++ b/services/data-wrapper/v1/fields/csv.ini
@@ -4,9 +4,10 @@ extension = json
 
 # OpenAPI Documentation - JSON format (dot notation)
 post.operationId = post-v1-fields-csv
-post.description = Récupération des colonnes d'un fichier CSV
-post.summary = Le fichier est analysé pour lister les colonnes utilisées
-post.tags.0 = data-wrapper
+post.summary = Récupération des colonnes d'un fichier CSV
+#' (colorization)
+post.description = Le fichier CSV est analysé pour lister les colonnes utilisées
+post.tags.0 = fields
 post.requestBody.content.text/csv.schema.type = string
 post.requestBody.content.text/csv.schema.format = binary
 post.requestBody.required = true

--- a/services/data-wrapper/v1/fields/json.ini
+++ b/services/data-wrapper/v1/fields/json.ini
@@ -1,0 +1,41 @@
+# Entrypoint output format
+mimeType = application/json
+extension = json
+
+# OpenAPI Documentation - JSON format (dot notation)
+post.operationId = post-v1-fields-json
+post.summary = Récupération des colonnes d'un fichier JSON
+#' (colorization)
+post.description = Le fichier JSON est analysé pour lister les champs de premier niveau utilisés
+post.tags.0 = fields
+post.requestBody.content.application/json.schema.type = string
+post.requestBody.content.application/json.schema.format = binary
+post.requestBody.required = true
+post.responses.default.description = Liste des champs trouvés
+post.responses.default.content.application/json.schema.$ref =  #/components/schemas/JSONStream
+post.responses.default.content.application/json.example.0.value = Title
+post.responses.default.content.application/json.example.1.value = Keywords
+post.parameters.0.description = Indenter le JSON résultant
+post.parameters.0.in = query
+post.parameters.0.name = indent
+post.parameters.0.schema.type = boolean
+
+[use]
+plugin = basics
+
+[JSONParse]
+
+[truncate]
+length = 1
+
+[exchange]
+value = self().keys()
+
+[ungroup]
+
+[replace]
+path = value
+value = self()
+
+[dump]
+indent = env('indent', false)

--- a/services/data-wrapper/v1/fields/jsonl.ini
+++ b/services/data-wrapper/v1/fields/jsonl.ini
@@ -1,0 +1,41 @@
+# Entrypoint output format
+mimeType = application/json
+extension = json
+
+# OpenAPI Documentation - JSON format (dot notation)
+post.operationId = post-v1-fields-jsonl
+post.summary = Récupération des colonnes d'un fichier JSONL
+#' (colorization)
+post.description = Le fichier JSONL est analysé pour lister les champs de premier niveau utilisés
+post.tags.0 = fields
+post.requestBody.content.application/jsonl.schema.type = string
+post.requestBody.content.application/jsonl.schema.format = binary
+post.requestBody.required = true
+post.responses.default.description = Liste des champs trouvés
+post.responses.default.content.application/json.schema.$ref =  #/components/schemas/JSONStream
+post.responses.default.content.application/json.example.0.value = Title
+post.responses.default.content.application/json.example.1.value = Keywords
+post.parameters.0.description = Indenter le JSON résultant
+post.parameters.0.in = query
+post.parameters.0.name = indent
+post.parameters.0.schema.type = boolean
+
+[use]
+plugin = basics
+
+[unpack]
+
+[truncate]
+length = 1
+
+[exchange]
+value = self().keys()
+
+[ungroup]
+
+[replace]
+path = value
+value = self()
+
+[dump]
+indent = env('indent', false)


### PR DESCRIPTION
À l’image de la route `fields/csv`, créer un service `fields/json` qui renvoie les noms des champs de premier niveau d’un JSON.