### PR TITLE
Update bases/ezs-python-server to ezs/core 4.0.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,6 +73,7 @@
         "TERMSUITE",
         "tess",
         "thefuzz",
+        "tini",
         "treetagger",
         "ungroup",
         "unidecode",

--- a/bases/ezs-python-server/Dockerfile
+++ b/bases/ezs-python-server/Dockerfile
@@ -1,6 +1,7 @@
 FROM cnrsinist/python-node:py3.9-no16-1.0.1
 
-RUN apt update && apt install -y tini && \
+RUN apt-get update && apt-get install -y --no-install-recommends tini && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo '{ \
     "httpPort": 31976, \
     "configPath": "/app/config.json", \
@@ -8,11 +9,12 @@ RUN apt update && apt install -y tini && \
     }' > /etc/ezmaster.json
 
 WORKDIR /app
-RUN npm install dotenv-cli@8.0.0 && \
-    npm install @ezs/core@3.11.2 && \
-    npm install @ezs/analytics@2.3.5 && \
-    npm install @ezs/basics@2.9.1 && \
-    npm install @ezs/spawn@1.4.8 && \
+RUN npm install --omit=dev dotenv-cli@10.0.0 && \
+    npm install --omit=dev @ezs/core@4.0.1 && \
+    npm install --omit=dev @ezs/analytics@2.3.5 && \
+    npm install --omit=dev @ezs/basics@2.9.2 && \
+    npm install --omit=dev @ezs/spawn@1.4.9 && \
+    npm cache clean --force && \
     chmod a+w /app
 
 # Make sure that .npm folder is readable by the daemon user

--- a/bases/ezs-python-server/config.json
+++ b/bases/ezs-python-server/config.json
@@ -3,10 +3,11 @@
         "EZS_TITLE": "ezs server",
         "EZS_DESCRIPTION": "web services",
         "EZS_METRICS": true,
-        "EZS_CONCURRENCY": 4,
+        "EZS_CONCURRENCY": 2,
         "EZS_CONTINUE_DELAY": 60,
         "EZS_NSHARDS": 32,
         "EZS_CACHE": true,
+        "EZS_VERBOSE": false,
         "NODE_OPTIONS": "--max_old_space_size=1024",
         "NODE_ENV": "production"
     }

--- a/bases/ezs-python-server/docker-entrypoint.sh
+++ b/bases/ezs-python-server/docker-entrypoint.sh
@@ -8,5 +8,12 @@ cd /app || exit 1
 node generate-dotenv.js
 cd /app/public || exit 2
 
+# Temporary fix for ezs bin
+# Likely due to old npm and node versions
+# TODO: remove when node version updated to 24
+mv /app/node_modules/@ezs/core/bin/ezs /app/node_modules/@ezs/core/bin/ezs.js
+rm /app/node_modules/.bin/ezs
+ln -s /app/node_modules/@ezs/core/bin/ezs.js /app/node_modules/.bin/ezs
+
 # Run ezs server as daemon user
-su -s /bin/bash daemon -c "npx dotenv -e ../.env -- npx ezs --daemon ./"
+su -s /bin/bash daemon -c "npx dotenv -e ../.env -- /app/node_modules/@ezs/core/bin/ezs.js --daemon ./"

--- a/bases/ezs-python-server/package.json
+++ b/bases/ezs-python-server/package.json
@@ -1,32 +1,33 @@
 {
-    "private": true,
-    "name": "ezs-python-server",
-    "version": "1.0.12",
-    "description": "ezs server + python",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/Inist-CNRS/web-services.git"
-    },
-    "keywords": [
-        "ezmaster"
-    ],
-    "author": "François Parmentier <francois.parmentier@gmail.com>",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/Inist-CNRS/web-services/issues"
-    },
-    "homepage": "https://github.com/Inist-CNRS/web-services/#readme",
-    "scripts": {
-        "version:insert": "sed -i \"s#\\(${npm_package_name}.\\)\\([\\.a-z0-9]\\+\\)#\\1${npm_package_version}#g\" README.md && git add README.md",
-        "version:commit": "git commit -a -m \"release ${npm_package_name}@${npm_package_version}\"",
-        "version:tag": "git tag \"${npm_package_name}@${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version}\"",
-        "version:push": "git push && git push --tags",
-        "version": "npm run version:insert && npm run version:commit && npm run version:tag",
-        "postversion": "npm run version:push && npm run build && npm run publish",
-        "build:dev": "docker build -t cnrsinist/${npm_package_name}:py3.9-no16-latest .",
-        "start:dev": "npm run build:dev && docker run --rm -p 31976:31976 cnrsinist/${npm_package_name}:py3.9-no16-latest",
-        "build": "docker build -t cnrsinist/${npm_package_name}:py3.9-no16-${npm_package_version} .",
-        "start": "docker run --rm -p 31976:31976 cnrsinist/${npm_package_name}:py3.9-no16-${npm_package_version}",
-        "publish": "docker push cnrsinist/${npm_package_name}:py3.9-no16-${npm_package_version}"
-    }
+  "private": true,
+  "name": "ezs-python-server",
+  "version": "1.0.12",
+  "description": "ezs server + python",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Inist-CNRS/web-services.git"
+  },
+  "keywords": [
+    "ezmaster"
+  ],
+  "author": "François Parmentier <francois.parmentier@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Inist-CNRS/web-services/issues"
+  },
+  "homepage": "https://github.com/Inist-CNRS/web-services/#readme",
+  "scripts": {
+    "version:insert": "sed -i \"s#\\(${npm_package_name}.\\)\\([\\.a-z0-9]\\+\\)#\\1${npm_package_version}#g\" README.md && git add README.md",
+    "version:commit": "git commit -a -m \"release ${npm_package_name}@${npm_package_version}\"",
+    "version:tag": "git tag \"${npm_package_name}@${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version}\"",
+    "version:push": "git push && git push --tags",
+    "version": "npm run version:insert && npm run version:commit && npm run version:tag",
+    "postversion": "npm run version:push && npm run build && npm run publish",
+    "build:check": "docker build --check -t cnrsinist/${npm_package_name}:latest  . && docker run --rm -i hadolint/hadolint hadolint - < Dockerfile ",
+    "build:dev": "docker build -t cnrsinist/${npm_package_name}:py3.9-no16-latest .",
+    "start:dev": "npm run build:dev && docker run --rm -p 31976:31976 cnrsinist/${npm_package_name}:py3.9-no16-latest",
+    "build": "docker build -t cnrsinist/${npm_package_name}:py3.9-no16-${npm_package_version} .",
+    "start": "docker run --rm -p 31976:31976 cnrsinist/${npm_package_name}:py3.9-no16-${npm_package_version}",
+    "publish": "docker push cnrsinist/${npm_package_name}:py3.9-no16-${npm_package_version}"
+  }
 }


### PR DESCRIPTION
L'objectif est d'avoir une image de base plus performante.

Voir [ezs benchmark](https://github.com/touv/ezs-benchmark/blob/main/README.md).

Étapes:

- [ ] update base image `ezs-python-server`
- [ ] publish `ezs-python-server` on docker hub
- [ ] update ezs packages in root `package.json`
- [ ] run `npm run update:images bases/ezs-python-server`
- [ ] publish `ezs-python-saxon-server` on docker hub
- [ ] publish `ezs-python-pytorch-server` on docker hub
- [ ] run `npm run update:images bases/ezs-python-saxon-server`
- [ ] run `npm run update:images bases/ezs-python-pytorch-server`
