### PR TITLE
Add generate:service-async script

### DIFF
--- a/SCRIPTS.md
+++ b/SCRIPTS.md
@@ -51,6 +51,25 @@ Author name : François Parmentier
 Author email: francois.parmentier@gmail.com
 ```
 
+## generate:service-async
+
+Usage: `npm run generate:service-async servicename`
+
+Scaffold the `services/data-servicename` directory, and customize all required
+files for an asynchronous service.
+
+Example:
+
+```bash
+$ npm run generate:service-async secondtest
+Creating service data-secondtest from template
+
+Short description: Deuxième test
+Long description : Pas vraiment le premier en fait.
+Author name : François Parmentier
+Author email: francois.parmentier@gmail.com
+```
+
 ## help
 
 Usage: `npm run help`

--- a/bin/create-async-service-from-template.sh
+++ b/bin/create-async-service-from-template.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# Usage: bin/create-service-from-template.sh <servicename>
+set -euo pipefail
+
+if [ ! -d "template-async" ]; then
+    echo "Could not find directory template-async"
+    exit 1
+fi
+
+SECOND_PART=$1
+SERVICE_NAME=data-$SECOND_PART
+
+if [ -d "services/$SERVICE_NAME" ]; then
+    echo "Service $SERVICE_NAME already exists"
+    exit 2
+fi
+
+if ! [[ $SERVICE_NAME =~ ^data-[a-z][a-z0-9]*$ ]]; then
+    echo "Error: Service name must comply with the pattern (first part: \"data-\", followed with an alphanumeric part, don't include \"data-\" part)."
+    exit 3
+fi
+
+printf "Creating service ""%s"" from template-async\n\n" "$SERVICE_NAME"
+
+printf "Short description: "
+read -r SHORT_DESCRIPTION
+
+printf "Long description : "
+read -r SUMMARY
+
+printf "Author name : "
+read -r AUTHOR_NAME
+
+printf "Author email: "
+read -r AUTHOR_EMAIL
+
+echo -ne "Copying template-async...    \r"
+
+cp -r template-async "services/$SERVICE_NAME"
+
+echo -ne "Customizing service...       \r"
+
+for FILE in services/"$SERVICE_NAME"/* services/"$SERVICE_NAME"/.env; do
+    if [ -f "$FILE" ]; then
+        sed -i "s/{service}/$SERVICE_NAME/g" "$FILE"
+        sed -i "s/{short_description}/$SHORT_DESCRIPTION/g" "$FILE"
+        sed -i "s/{summary}/$SUMMARY/g" "$FILE"
+        sed -i "s/{author_name}/$AUTHOR_NAME/g" "$FILE"
+        sed -i "s/{author_email}/$AUTHOR_EMAIL/g" "$FILE"
+    fi
+done
+
+# Add service to workspaces in package.json
+echo -ne "Adding workspace...          \r"
+
+node <<EOF
+const packageJson = require('./package.json');
+packageJson.workspaces = (packageJson.workspaces ?? [])
+    .concat(['services/$SERVICE_NAME'])
+    .sort()
+    .reduce(
+        (acc, curr) => acc.includes(curr) ? acc : [...acc, curr],
+        []
+    );
+
+require('fs').writeFileSync(
+    './package.json',
+     JSON.stringify(packageJson, null, 2)
+)
+EOF
+
+# Add service to list of services in README
+echo -ne "Updating README...     \r"
+
+sed -n '1,/## Services/p' < README.md > README.tmp
+echo "" >> README.tmp
+node <<EOF >> README.tmp
+const workspaces = require('./package.json').workspaces;
+const services = workspaces.reduce(
+    (acc, curr) => {
+        if (!curr.startsWith('services/')) {
+            return acc;
+        }
+        const service = curr.split('/')[1];
+        return acc +
+            \`- [\${service}](./services/\${service}) [![Docker Pulls](https://img.shields.io/docker/pulls/cnrsinist/ws-\${service}.svg)](https://hub.docker.com/r/cnrsinist/ws-\${service}/)\n\`;
+    }, ''
+);
+console.log(services.substr(0, services.length - 1));
+EOF
+mv README.md README.back
+mv README.tmp README.md
+rm README.back
+
+echo -e "\rDone                        "

--- a/bin/create-service-from-template.sh
+++ b/bin/create-service-from-template.sh
@@ -40,7 +40,7 @@ cp -r template "services/$SERVICE_NAME"
 
 echo -ne "Customizing service... \r"
 
-for FILE in "services/$SERVICE_NAME"/*; do
+for FILE in services/"$SERVICE_NAME"/* services/"$SERVICE_NAME"/.env; do
     if [ -f "$FILE" ]; then
         sed -i "s/{service}/$SERVICE_NAME/g" "$FILE"
         sed -i "s/{short_description}/$SHORT_DESCRIPTION/g" "$FILE"

--- a/bin/update-images.sh
+++ b/bin/update-images.sh
@@ -53,7 +53,7 @@ function updateBase() {
     BASE_IMAGE_TAG="$BASE_IMAGE_TAG_BEGINNING-$BASE_IMAGE_VERSION"
     printf "Tag of the image: %s\n\n" "$BASE_IMAGE_TAG"
 
-    DOCKERFILES=$(ls bases/*/Dockerfile template/Dockerfile services/*/Dockerfile)
+    DOCKERFILES=$(ls bases/*/Dockerfile template*/Dockerfile services/*/Dockerfile)
 
 
     printf "Directly depending images:\n"
@@ -73,9 +73,9 @@ function updateBase() {
         run "sed -i -e \"s/cnrsinist\/$CHANGING_BASE:.*$/cnrsinist\/$CHANGING_BASE:$BASE_IMAGE_TAG/g\" \"$DOCKERFILE\""
         IMAGE_DIR=$(dirname "$DOCKERFILE")
         TYPE=$(dirname "$IMAGE_DIR")
-        if [ "$IMAGE_DIR" = "template" ]; then
-            run git add template
-            run "git commit -m \"Update template to $CHANGING_BASE:$BASE_IMAGE_TAG\""
+        if [ "$IMAGE_DIR" = "template" ] || [ "$IMAGE_DIR" = "template-async" ]; then
+            run git add "$IMAGE_DIR"
+            run "git commit -m \"Update $IMAGE_DIR to $CHANGING_BASE:$BASE_IMAGE_TAG\""
             run git push
         else
             run "npm -w \"$IMAGE_DIR\" version patch"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "generate:example-metadata": "node bin/generate-example-metadata.mjs",
     "generate:example-tests": "node bin/generate-example-tests.mjs",
     "generate:service": "./bin/create-service-from-template.sh",
+    "generate:service-async": "./bin/create-async-service-from-template.sh",
     "help": "bat SCRIPTS.md || cat SCRIPTS.md",
     "insert:description": "./bin/insert-description.sh",
     "insert:swagger:description": "./bin/insert-swagger-description.sh",

--- a/services/data-termsuite/v1/en.ini
+++ b/services/data-termsuite/v1/en.ini
@@ -4,6 +4,7 @@ mimeType = application/json
 # OpenAPI Documentation - JSON format (dot notation)
 post.operationId = post-v1-en
 post.summary = Extraction des termes d'un fichier corpus en anglais
+#'
 post.description = Procède à une extraction terminologique en langue anglaise sur un corpus de textes.  ^M^MLe fichier `.tar.gz` envoyé doit contenir des fichiers `.json` dont chacun^Mcontient un objet dont le champ `value` contient un texte en anglais et le champ^M`id` un identifiant unique pouvant servir de nom de fichier.  ^M^Mℹ️ Voir [la commande Unix `tar`](https://tldr.inbrowser.app/pages/common/tar).^M^MCe format de fichier,appelé corpus compressé, est celui renvoyé par les services^Mweb `data-wrapper`s (convertisseurs).^M^Mℹ️ Voir [les services web `data-wrapper`](https://openapi.services.istex.fr/?urls.primaryName=data-wrapper%20-%20Conversions%20en%20fichier%20corpus%20compress%C3%A9).
 post.tags.0 = data-termsuite
 post.requestBody.content.application/x-gzip.schema.type = string

--- a/template-async/.dockerignore
+++ b/template-async/.dockerignore
@@ -1,0 +1,7 @@
+# Ignore all files by default
+*
+
+# White list only the required files
+!config.json
+!v1
+!swagger.json

--- a/template-async/.env
+++ b/template-async/.env
@@ -1,0 +1,17 @@
+# If DVC is used, uncomment these lines (and put your values)
+# NOTE: this file is ignored by git, it should not be present in any services/* directory.
+# export WEBDAV_URL=webdavs://url.of.your.dvc.remote
+# export WEBDAV_LOGIN=real-login
+# export WEBDAV_PASSWORD=real-password
+
+# You can also add any API KEY below.
+
+# Next, remove the following lines:
+echo "*** {service} ***"
+echo
+echo "Un fichier .env existe, mais il faut:"
+echo "- soit renseigner les variables si vous utilisez DVC"
+echo "- soit ajouter les variables d'environnement que vous voulez utiliser (clés d'API, ou autre)"
+echo
+echo "En tout cas, une fois que c'est fait, supprimez ces messages dans services/{service}/.env"
+echo "******"

--- a/template-async/Dockerfile
+++ b/template-async/Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1.2
+
+# FROM python:3.9-slim-bullseye AS dvc-files
+# WORKDIR /dvc
+# RUN apt-get update && \
+#     apt-get install -y --no-install-recommends git=1:2.30.2-1+deb11u5 curl=7.74.0-1.3+deb11u16 && \
+#     apt-get clean && \
+#     rm -rf /var/lib/apt/lists/*
+# RUN pip install --no-cache-dir dvc[webdav]==3.67.1
+# RUN --mount=type=secret,id=webdav_login \
+#     --mount=type=secret,id=webdav_password \
+#     --mount=type=secret,id=webdav_url \
+#     git init && \
+#     dvc init && \
+#     dvc remote add -d webdav-remote "$(cat /run/secrets/webdav_url)" && \
+#     dvc remote modify --local webdav-remote user "$(cat /run/secrets/webdav_login)" && \
+#     dvc remote modify --local webdav-remote password "$(cat /run/secrets/webdav_password)"
+# COPY ./v1/data.dvc /dvc
+## The cat part is useful for files larger than 500Mio.
+# RUN dvc pull -v && \
+#     cat data/x* > data/resources.txt && \
+#     rm data/x*
+
+FROM cnrsinist/ezs-python-server:py3.9-no24-1.0.13
+
+WORKDIR /app
+# Install all python dependencies
+# RUN pip install --no-cache-dir \
+#     unidecode==1.3.7
+
+# Install all node dependencies
+# RUN npm install --omit=dev \
+#         @ezs/teeft@2.3.2 \
+#         @ezs/strings@1.0.5 && \
+#     npm cache clean --force
+
+WORKDIR /app/public
+# Declare files to copy in .dockerignore
+COPY --chown=daemon:daemon . /app/public/
+COPY --chown=daemon:daemon ./config.json /app/config.json
+# Copy DVC files
+#COPY --chown=daemon:daemon --from=dvc-files /dvc/data/ /app/public/v1/

--- a/template-async/README.md
+++ b/template-async/README.md
@@ -1,0 +1,8 @@
+# ws-{service}@0.0.0
+
+{short_description}
+
+{summary}
+
+<!-- Mettez ici les explications techniques destinées aux développeurs / mainteneurs de {service} -->
+<!-- Par exemple, l'utilisation de DVC, ou de clé d'API. -->

--- a/template-async/config.json
+++ b/template-async/config.json
@@ -1,0 +1,15 @@
+{
+    "environnement": {
+        "EZS_TITLE": "{short_description}",
+        "EZS_DESCRIPTION": "{summary}",
+        "EZS_METRICS": true,
+        "EZS_CONCURRENCY": 2,
+        "EZS_PIPELINE_DELAY": 10800,
+        "EZS_CONTINUE_DELAY": 60,
+        "EZS_NSHARDS": 32,
+        "EZS_CACHE": true,
+        "EZS_VERBOSE": false,
+        "NODE_OPTIONS": "--max_old_space_size=1024",
+        "NODE_ENV": "production"
+    }
+}

--- a/template-async/package.json
+++ b/template-async/package.json
@@ -1,0 +1,37 @@
+{
+  "private": true,
+  "name": "ws-{service}",
+  "version": "0.0.0",
+  "description": "{short_description}",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Inist-CNRS/web-services.git"
+  },
+  "keywords": [
+    "ezmaster"
+  ],
+  "author": "{author_name} <{author_email}>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Inist-CNRS/web-services/issues"
+  },
+  "homepage": "https://github.com/Inist-CNRS/web-services/#readme",
+  "scripts": {
+    "version:insert:readme": "sed -i \"s#\\(${npm_package_name}.\\)\\([\\.a-z0-9]\\+\\)#\\1${npm_package_version}#g\" README.md && git add README.md",
+    "version:insert:swagger": "sed -i \"s/\\\"version\\\": \\\"[0-9]\\+.[0-9]\\+.[0-9]\\+\\\"/\\\"version\\\": \\\"${npm_package_version}\\\"/g\" swagger.json && git add swagger.json",
+    "version:insert": "npm run version:insert:readme && npm run version:insert:swagger",
+    "version:commit": "git commit -a -m \"release ${npm_package_name}@${npm_package_version}\"",
+    "version:tag": "git tag \"${npm_package_name}@${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version}\"",
+    "version:push": "git push && git push origin \"${npm_package_name}@${npm_package_version}\"",
+    "version": "npm run version:insert && npm run version:commit && npm run version:tag",
+    "postversion": "npm run version:push",
+    "build:check": "DOCKER_BUILDKIT=1 docker build --check -t cnrsinist/${npm_package_name}:latest . && docker run --rm -i hadolint/hadolint hadolint - < Dockerfile ",
+    "build:dev": ". ./.env 2> /dev/null; DOCKER_BUILDKIT=1 docker build -t cnrsinist/${npm_package_name}:latest --secret id=webdav_login,env=WEBDAV_LOGIN --secret id=webdav_password,env=WEBDAV_PASSWORD --secret id=webdav_url,env=WEBDAV_URL .",
+    "start:dev": ". ./.env 2> /dev/null; npm run build:dev && docker run --name dev --rm --detach -p 31976:31976 cnrsinist/${npm_package_name}:latest",
+    "stop:dev": "docker stop dev",
+    "build": ". ./.env 2> /dev/null; DOCKER_BUILDKIT=1 docker build -t cnrsinist/${npm_package_name}:${npm_package_version} --secret id=webdav_login,env=WEBDAV_LOGIN --secret id=webdav_password,env=WEBDAV_PASSWORD --secret id=webdav_url,env=WEBDAV_URL .",
+    "start": "docker run --rm -p 31976:31976 cnrsinist/${npm_package_name}:${npm_package_version}",
+    "publish": "docker push cnrsinist/${npm_package_name}:${npm_package_version}"
+  },
+  "avoid-testing": false
+}

--- a/template-async/swagger.json
+++ b/template-async/swagger.json
@@ -1,0 +1,33 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "{service} - {short_description}",
+        "description": "{summary}",
+        "version": "0.0.0",
+        "termsOfService": "https://services.istex.fr/",
+        "contact": {
+            "name": "Inist-CNRS",
+            "url": "https://www.inist.fr/nous-contacter/"
+        }
+    },
+    "servers": [
+        {
+            "x-comment": "Will be automatically completed by the ezs server."
+        },
+        {
+            "url": "http://vptdmjobs.intra.inist.fr:49225/",
+            "description": "Latest version for production",
+            "#DISABLED#x-profil": "Standard"
+        }
+    ],
+    "tags": [
+        {
+            "name": "{service}",
+            "description": "{short_description}",
+            "externalDocs": {
+                "description": "Plus de documentation",
+                "url": "https://github.com/inist-cnrs/web-services/tree/main/services/{service}"
+            }
+        }
+    ]
+}

--- a/template-async/tests.hurl
+++ b/template-async/tests.hurl
@@ -1,0 +1,62 @@
+## Principes
+#
+# Les services web asynchrones nécessitent plusieurs appels pour être testés:
+#
+# - l'appel du traitement (qui nécessite généralement l'envoi d'un corpus sous
+#   forme de .tar.gz)
+# - l'appel du résultat (au bout d'un temps suffisant pour que le traitement
+#   soit terminé)
+#
+# À la fin de l'appel du traitement, on récupère l'identifiant du traitement
+# dans computing_token.
+# C'est la variable qui servira à la route de retrieve pour savoir quel résultat
+# retourner.
+#
+# On peut tester plusieurs routes de retrieve sans avoir besoin de relancer le
+# traitement.
+#
+# Les assertions à écrire sont celles du retrieve, qui vérifie que le résultat a
+# bien la forme et/ou les valeurs attendues.
+# Voir la documentation de Hurl pour ça:
+# https://hurl.dev/docs/asserting-response.html#json-body
+#
+## Usage
+# npm run test:local {service}
+# npm run test:remote {service}
+
+##################################################
+## treatment
+##################################################
+POST {{host}}/v1/treatment-route
+content-type: application/x-tar
+# x-hook: https://webhook.site/69300b22-a251-4c16-9905-f7ba218ae7e9
+file,example.tar.gz;
+
+HTTP 200
+# Capture the computing token
+[Captures]
+computing_token: jsonpath "$[0].value"
+[Asserts]
+variable "computing_token" exists
+
+
+POST {{host}}/v1/retrieve-json?indent=true
+content-type: application/json
+[Options]
+delay:60000
+```
+[
+	{
+		"value":"{{computing_token}}"
+	}
+]
+```
+
+HTTP 200
+[Asserts]
+jsonpath "$[0].value[0].entity" == "Geneva"
+jsonpath "$[0].value[0].alignment" count > 0
+jsonpath "$[0].value[0].alignment[0]" contains "geonames.org"
+jsonpath "$[0].value[2].entity" == "Paris"
+jsonpath "$[0].value[2].alignment" count > 0
+jsonpath "$[0].value[2].alignment[0]" contains "geonames.org"

--- a/template-async/v1/buffer.cfg
+++ b/template-async/v1/buffer.cfg
@@ -1,0 +1,30 @@
+[use]
+plugin = basics
+
+# On sauvegarde sur disque pour accepter rapidement tous les objets en entrée
+# et répondre rapidement au client que le traitement asynchrone est lancé.
+#
+# Le "fork" se détache uniquement quand tous les objets sont "rentrés" dans le fork
+# Si le traitement est plus lent que la sauvegarde sur disque
+# il est nécessaire de créer un fichier temporaire
+[pack]
+[FILESave]
+identifier = env('identifier')
+location = /tmp/upload
+compress = true
+
+# Ajouter une trace dans le log
+[combine]
+primer = Data received
+file = timestamp.cfg
+
+[exchange]
+value = get('filename')
+
+[FILELoad]
+compress = true
+location = /tmp/upload
+[unpack]
+
+[metrics]
+bucket = buffer

--- a/template-async/v1/charger.cfg
+++ b/template-async/v1/charger.cfg
@@ -1,0 +1,35 @@
+[use]
+plugin = basics
+
+# Step 0 (générique) : Lire le fichier standard tar.gz
+[TARExtract]
+compress = true
+path = */*.json
+
+# Step 1 (générique) : Créer un identifiant unique pour le corpus reçu
+[singleton]
+
+# Step 1.1 : On évite de récupérer un champ uri existant
+[singleton/env]
+path = pid
+value = fix(`PID${Date.now()}`)
+
+# Step 1.2 : On génère un identifiant unique
+[singleton/identify]
+path = env('pid')
+
+# Step 1.3: On garde en mémoire l'identifiant généré (en le simplifiant)
+[singleton/env]
+path = identifier
+value = get(env('pid')).replace('uid:/', '')
+
+[singleton/exchange]
+value = self().omit([env('pid')])
+
+[metrics]
+bucket = charger
+
+# Ajouter une trace dans le log
+[combine]
+primer = Data loaded
+file = timestamp.cfg

--- a/template-async/v1/logger.cfg
+++ b/template-async/v1/logger.cfg
@@ -1,0 +1,59 @@
+; [use]
+plugin = basics
+plugin = analytics
+
+[metrics]
+bucket = logger
+
+# On ne garde que la première erreur déclenchée
+[shift]
+
+# Ajouter une trace dans le log
+[combine]
+primer = Error trapped
+file = timestamp.cfg
+
+[assign]
+path = body.identifier
+value = env('identifier')
+
+path = body.generator
+value = env('generator')
+
+path = body.error.type
+value = get('type')
+
+path = body.error.scope
+value = get('scope')
+
+path = body.error.message
+value = get('message')
+
+path = env
+value = env()
+
+[swing]
+test = env('headers.x-webhook-failure').startsWith('http')
+
+[swing/URLFetch]
+url = env('headers.x-webhook-failure').trim()
+path = body
+headers = Content-Type:application/json
+target = result
+retries = 5
+timeout = 30000
+
+# On enregistre uniquement quelques informations (à supprimer pour avoir la trace complète)
+[exchange]
+value = get('body')
+
+[FILESave]
+location = /tmp/retrieve
+identifier = env('identifier')
+jsonl = true
+compress = false
+
+# Ajouter une trace dans le log
+[combine]
+primer = Error was saved
+file = timestamp.cfg

--- a/template-async/v1/recipient.cfg
+++ b/template-async/v1/recipient.cfg
@@ -1,0 +1,14 @@
+[use]
+plugin = basics
+
+[shift]
+[replace]
+path = id
+value = env('generator')
+path = value
+value = env('identifier')
+path = retrieve-json
+value = /v1/retrieve-json
+
+[JSONString]
+indent = env('indent')

--- a/template-async/v1/recorder.cfg
+++ b/template-async/v1/recorder.cfg
@@ -1,0 +1,60 @@
+[use]
+plugin = basics
+plugin = analytics
+
+# Ajouter une trace dans le log
+[singleton]
+[singleton/combine]
+primer = One first result received
+file = timestamp.cfg
+
+[metrics]
+bucket = recorder
+
+# Step 2.2 (générique): Création d'un fichier résultat standard
+[TARDump]
+compress = true
+manifest = fix({version: '1'})
+manifest = fix({identifier: env('identifier')})
+manifest = fix({generator: env('generator')})
+
+# Step 2.3 (générique): Sauvegarder sur disque le résultat
+[FILESave]
+location = /tmp/retrieve
+identifier = env('identifier')
+jsonl = false
+compress = false
+
+# Ajouter une trace dans le log
+[combine]
+primer = Result generated
+file = timestamp.cfg
+
+# Step 2.4 (générique): Signaler la fin du traitement via un appel à un webhook (si il a été précisé)
+[swing]
+test = env('headers.x-webhook-success').startsWith('http')
+
+# Step 2.4.1 (générique): Sélectionner les informations à envoyer au webhook
+[swing/replace]
+path = url
+value = env('headers.x-webhook-success')
+path = body
+value = self().pick(['size', 'atime', 'mtime', 'ctime']).set('identifier', env('identifier')).set('generator', env('generator')).set('state', 'ready')
+
+# Step 2.4.2 (générique): Envoyer la requête HTTP
+[swing/URLFetch]
+url = env('headers.x-webhook-success').trim()
+path = body
+headers = Content-Type:application/json
+retries = 5
+timeout = 30000
+
+# Step 2.4.3 (facultatif) : Ajouter une trace dans le log
+[swing/combine]
+primer = WebHook triggered
+file = timestamp.cfg
+
+# Step 2.5 : Ajouter une trace dans le log
+[combine]
+primer = Process completed
+file = timestamp.cfg

--- a/template-async/v1/retrieve-status.ini
+++ b/template-async/v1/retrieve-status.ini
@@ -1,0 +1,27 @@
+# Entrypoint output format
+mimeType = application/jsonl
+extension = jsonl
+
+# OpenAPI Documentation - JSON format (dot notation)
+post.operationId = post-v1-retrieve-status
+post.summary = Récupération du statut d'un traitement
+#'
+post.description = Les traitements étant asynchrones le statut du traitement peut-être récupéré par cette route
+post.tags.0 = retrieves
+post.responses.default.description = Fichier corpus au format jsonl
+post.responses.default.content.application/jsonl.schema.type = string
+post.requestBody.content.application/json.example.0.value = xMkWJX7GU
+post.requestBody.content.application/json.schema.$ref = #/components/schemas/JSONStream
+post.requestBody.required = true
+
+[use]
+plugin = basics
+
+[JSONParse]
+separator = *
+
+[exchange]
+value = get('value')
+
+[FILELoad]
+location = /tmp/logs

--- a/template-async/v1/timestamp.cfg
+++ b/template-async/v1/timestamp.cfg
@@ -1,0 +1,23 @@
+[debug]
+text = timestamp
+
+[fork]
+standalone = true
+logger = logger.cfg
+
+[fork/replace]
+path = timestamp
+value = fix(Date.now())
+path = generator
+value = env('generator')
+path = identifier
+value = env('identifier')
+path = message
+value = self()
+
+[fork/FILESave]
+location = /tmp/logs
+identifier = env('identifier')
+jsonl = true
+compress = false
+append = true

--- a/template-async/v1/to-rename.ini
+++ b/template-async/v1/to-rename.ini
@@ -1,0 +1,63 @@
+# Entrypoint output format
+mimeType = application/json
+
+# OpenAPI Documentation - JSON format (dot notation)
+post.operationId = post-v1-to-rename
+post.summary = ${short_description}
+#'
+post.description = {summary}
+post.tags.0 = data-termsuite
+post.requestBody.content.application/x-gzip.schema.type = string
+post.requestBody.content.application/x-gzip.schema.format = binary
+post.requestBody.required = true
+post.responses.default.description = Informations permettant de récupérer les données le moment venu
+post.parameters.0.description = URL pour signaler que le traitement est terminé
+post.parameters.0.in = header
+post.parameters.0.name = X-Webhook-Success
+post.parameters.0.schema.type = string
+post.parameters.0.schema.format = uri
+post.parameters.0.required = false
+post.parameters.1.description = URL pour signaler que le traitement a échoué
+post.parameters.1.in = header
+post.parameters.1.name = X-Webhook-Failure
+post.parameters.1.schema.type = string
+post.parameters.1.schema.format = uri
+post.parameters.1.required = false
+
+post.responses.default.content.application/json.example.0.id = {service}
+post.responses.default.content.application/json.example.0.value = cEeFstsZi
+
+[use]
+plugin = @ezs/spawn
+
+[env]
+path = generator
+value = termsuite-en
+
+# Step 1 (générique): Charger le fichier corpus
+[delegate]
+file = charger.cfg
+
+# Step 2 (générique): Traiter de manière asynchrone les items reçus
+[fork]
+standalone = true
+logger = logger.cfg
+
+# Step 2.0 (optionnel): Accélère le détachement du fork si l'enrichissement est lent
+[fork/delegate]
+file = buffer.cfg
+
+# Step 2.1 (spécifique): Lancer un calcul sur tous les items reçus
+[fork/exec]
+# command should be executable!
+command = ./v1/to-rename.py
+args = nb
+args = env('nb')
+
+# Step 2.2 (générique): Enregistrer le résultat et signaler que le traitement est fini
+[fork/delegate]
+file = recorder.cfg
+
+# Step 3 : Renvoyer immédiatement un seul élément indiquant comment récupérer le résultat quand il sera prêt
+[delegate]
+file = recipient.cfg

--- a/template-async/v1/to-rename.py
+++ b/template-async/v1/to-rename.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+# main
+for line in sys.stdin:
+    data = json.loads(line)
+
+    # Add a modification of data["value"] here
+
+    sys.stdout.write(json.dumps(data))
+    sys.stdout.write("\n")

--- a/template/.env
+++ b/template/.env
@@ -1,0 +1,17 @@
+# If DVC is used, uncomment these lines (and put your values)
+# NOTE: this file is ignored by git, it should not be present in any services/* directory.
+# export WEBDAV_URL=webdavs://url.of.your.dvc.remote
+# export WEBDAV_LOGIN=real-login
+# export WEBDAV_PASSWORD=real-password
+
+# You can also add any API KEY below.
+
+# Next, remove the following lines:
+echo "*** {service} ***"
+echo
+echo "Un fichier .env existe, mais il faut:"
+echo "- soit renseigner les variables si vous utilisez DVC"
+echo "- soit ajouter les variables d'environnement que vous voulez utiliser (clés d'API, ou autre)"
+echo
+echo "En tout cas, une fois que c'est fait, supprimez ces messages dans services/{service}/.env"
+echo "******"


### PR DESCRIPTION
Afin d'éviter les copier-coller d'un service asynchrone pas à jour lors de la création d'un nouveau.
Sur le modèle du script [generate:service](https://github.com/Inist-CNRS/web-services/blob/main/SCRIPTS.md#generateservice), un script `generate:async-service`, avec un template propre `template-async`.  
Cela fera aussi une référence sur l'implémentation d'un service asynchrone.