### PR TITLE
[terms-extraction] use parallel detach instead of expand for teeft

### DIFF
--- a/.github/workflows/test-and-publish-on-tag.yml
+++ b/.github/workflows/test-and-publish-on-tag.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Install Hurl
         run: |
-          curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/5.0.1/hurl_5.0.1_amd64.deb
-          sudo dpkg -i hurl_5.0.1_amd64.deb
+          curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/8.0.1/hurl_8.0.1_amd64.deb
+          sudo dpkg -i hurl_8.0.1_amd64.deb
           hurl --version
 
       - name: Docker Login

--- a/.github/workflows/test-on-branch.yml
+++ b/.github/workflows/test-on-branch.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Install Hurl
         run: |
-          curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/5.0.1/hurl_5.0.1_amd64.deb
-          sudo dpkg -i hurl_5.0.1_amd64.deb
+          curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/8.0.1/hurl_8.0.1_amd64.deb
+          sudo dpkg -i hurl_8.0.1_amd64.deb
           hurl --version
 
       - name: Build .env from Github Actions secrets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,21 +31,21 @@ npm -w services/<name> run build:check
 npm run generate:example-tests services/<name>
 
 # Run tests (service must be running locally)
-HURL_blocked=false npm run test:local <name>
+HURL_VARIABLE_blocked=false npm run test:local <name>
 
 # Run tests against production
-HURL_blocked=false npm run test:remote <name>
+HURL_VARIABLE_blocked=false npm run test:remote <name>
 
 # Run tests for multiple services in production
-HURL_blocked=false npm run test:remotes services/*
+HURL_VARIABLE_blocked=false npm run test:remotes services/*
 
 # Single test with hurl directly
-HURL_blocked=false hurl --test --variable host=http://localhost:31976 --jobs 1 services/<name>/tests.hurl
+HURL_VARIABLE_blocked=false hurl --test --variable host=http://localhost:31976 --jobs 1 services/<name>/tests.hurl
 ```
 
-> **Note**: `HURL_blocked=false` is required for tests accessing protected APIs (e.g., ISTEX services). Export it in `~/.bashrc` to avoid repeating it:
+> **Note**: `HURL_VARIABLE_blocked=false` is required for tests accessing protected APIs (e.g., ISTEX services). Export it in `~/.bashrc` to avoid repeating it:
 > ```sh
-> export HURL_blocked=false
+> export HURL_VARIABLE_blocked=false
 > ```
 
 ## Code Style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -487,27 +487,27 @@ Cela donne accès aux informations de débogage interne de `ezs`.
 Pour tester un service lancé localement, utiliser:
 
 ```bash
-HURL_blocked=false npm run test:local service-name
+HURL_VARIABLE_blocked=false npm run test:local service-name
 ```
 
 Pour tester un service en production, taper:
 
 ```bash
-HURL_blocked=false npm run test:remote service-name
+HURL_VARIABLE_blocked=false npm run test:remote service-name
 ```
 
 Pour tester tous les services en production qui ont un fichier
 `tests.hurl`:
 
 ```bash
-HURL_blocked=false npm run test:remotes services/*
+HURL_VARIABLE_blocked=false npm run test:remotes services/*
 ```
 
 Pour tester uniquement certains services en production (à condition qu'ils aient
 un fichier `tests.hurl`):
 
 ```bash
-HURL_blocked=false npm run test:remotes service-name service2-name
+HURL_VARIABLE_blocked=false npm run test:remotes service-name service2-name
 ```
 
 > [!TIP]  
@@ -528,7 +528,7 @@ publié (sans URL externe), en se basant sur l'URL présente dans `swagger.json`
 ```
 
 > [!IMPORTANT]  
-> La partie `HURL_blocked=false` permet de préciser qu'on veut lancer *tous* les
+> La partie `HURL_VARIABLE_blocked=false` permet de préciser qu'on veut lancer *tous* les
 > tests du fichier `tests.hurl` concerné.  
 > Cette variable d'environnement est là pour permettre de lancer les tests d'un
 > fichier `tests.hurl` tout en ignorant ceux qui nécessitent un accès aux
@@ -538,10 +538,10 @@ publié (sans URL externe), en se basant sur l'URL présente dans `swagger.json`
 > production.  
 > Dans ce cas, ou quand l'ordinateur depuis lequel on veut lancer les tests n'a
 > pas d'IP autorisée (par exemple chez soi, sans le VPN), on doit positionner la
-> variable `HURL_blocked` à `true`.  
+> variable `HURL_VARIABLE_blocked` à `true`.  
 
 > [!TIP]  
-> Pour ne pas avoir à taper systématiquement `HURL_blocked=false` avant toute
+> Pour ne pas avoir à taper systématiquement `HURL_VARIABLE_blocked=false` avant toute
 > commande de lancement de tests, on peut exporter cette variable depuis son
 > `~/.bashrc` (si vous utilisez bash):  
 >
@@ -549,7 +549,7 @@ publié (sans URL externe), en se basant sur l'URL présente dans `swagger.json`
 > # hurl variable to skip tests accessing protected (blocked) API
 > # true: You are not able to access *.services.istex.fr
 > # false: You are able to access *.services.istex.fr
-> export HURL_blocked=false
+> export HURL_VARIABLE_blocked=false
 > ```
 
 ## Ajout dans la liste du README

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -44,7 +44,7 @@ This will start the service in a Docker container.
 To test a service, run the following command from the root of the project:
 
 ```bash
-HURL_blocked=false npm run test:local <service-name>
+HURL_VARIABLE_blocked=false npm run test:local <service-name>
 ```
 
 ## Development Conventions

--- a/package.json
+++ b/package.json
@@ -94,15 +94,15 @@
     "@ezs/basics": "2.13.0",
     "@ezs/core": "4.2.4",
     "@ezs/spawn": "1.4.10",
-    "@orangeopensource/hurl": "5.0.1",
+    "@orangeopensource/hurl": "8.0.4",
     "rest-cli": "1.8.13"
   },
   "devDependencies": {
     "@types/node": "24.13.3"
   },
   "allowScripts": {
-    "@orangeopensource/hurl@5.0.1": true,
     "better-sqlite3@12.8.0": true,
-    "leveldown@6.1.1": true
+    "leveldown@6.1.1": true,
+    "@orangeopensource/hurl@8.0.4": true
   }
 }

--- a/services/data-termsuite/tests.hurl
+++ b/services/data-termsuite/tests.hurl
@@ -18,7 +18,7 @@ HTTP 200
 # Capture the computing token
 [Captures]
 computing_token: jsonpath "$[0].value"
-retrieve_route: jsonpath "$[0].retrieve-json"
+retrieve_route: jsonpath "$[0]['retrieve-json']"
 [Asserts]
 variable "computing_token" exists
 variable "retrieve_route" exists
@@ -111,7 +111,7 @@ HTTP 200
 # Capture the computing token
 [Captures]
 fr_computing_token: jsonpath "$[0].value"
-retrieve_route: jsonpath "$[0].retrieve-json"
+retrieve_route: jsonpath "$[0]['retrieve-json']"
 [Asserts]
 variable "fr_computing_token" exists
 variable "retrieve_route" exists
@@ -183,7 +183,7 @@ HTTP 200
 # Capture the computing token
 [Captures]
 fr_computing_token: jsonpath "$[0].value"
-retrieve_route: jsonpath "$[0].retrieve-json"
+retrieve_route: jsonpath "$[0]['retrieve-json']"
 [Asserts]
 variable "fr_computing_token" exists
 variable "retrieve_route" exists

--- a/services/data-termsuite/tests.hurl
+++ b/services/data-termsuite/tests.hurl
@@ -143,11 +143,11 @@ HTTP 200
 Content-Type: application/json
 [Asserts]
 jsonpath "$" count == 5
-jsonpath "$[*].key" includes "a: thermique"
-jsonpath "$[*].key" includes "n: fission"
-jsonpath "$[*].key" includes "n: biomasse"
-jsonpath "$[*].key" includes "na: énergie éolien"
-jsonpath "$[*].key" includes "a: électrique"
+jsonpath "$[*].key" contains "a: thermique"
+jsonpath "$[*].key" contains "n: fission"
+jsonpath "$[*].key" contains "n: biomasse"
+jsonpath "$[*].key" contains "na: énergie éolien"
+jsonpath "$[*].key" contains "a: électrique"
 
 # Order is not guaranteed
 #[{
@@ -215,8 +215,8 @@ HTTP 200
 Content-Type: application/json
 [Asserts]
 jsonpath "$" count == 5
-jsonpath "$[*].id" includes "a: thermique"
-jsonpath "$[*].id" includes "n: fission"
-jsonpath "$[*].id" includes "n: biomasse"
-jsonpath "$[*].id" includes "na: énergie éolien"
-jsonpath "$[*].id" includes "a: électrique"
+jsonpath "$[*].id" contains "a: thermique"
+jsonpath "$[*].id" contains "n: fission"
+jsonpath "$[*].id" contains "n: biomasse"
+jsonpath "$[*].id" contains "na: énergie éolien"
+jsonpath "$[*].id" contains "a: électrique"

--- a/services/data-workflow/README.md
+++ b/services/data-workflow/README.md
@@ -24,8 +24,8 @@ Les tests destinés à être joués sur GitHub sont dans `tests.hurl`, mais ils 
 limités à la route `v1/base-line`, qui est la seule à ne pas faire appel à un
 service web.
 
-Pour réellement tester les autres routes, utilisez la variable `HURL_blocked`, et mettez-la à `false`, pour signaler que vous lancez les tests depuis une adresse IP autorisée à accéder aux services ISTEX:
+Pour réellement tester les autres routes, utilisez la variable `HURL_VARIABLE_blocked`, et mettez-la à `false`, pour signaler que vous lancez les tests depuis une adresse IP autorisée à accéder aux services ISTEX:
 
 ```bash
-HURL_blocked=false npm run test:local data-workflow
+HURL_VARIABLE_blocked=false npm run test:local data-workflow
 ```

--- a/services/data-workflow/tests.hurl
+++ b/services/data-workflow/tests.hurl
@@ -1,9 +1,9 @@
 # WARNING: This file was not generated, but manually written.
 # DON'T OVERWRITE IT
 # Use it to test:
-# 	HURL_blocked=false npx hurl --test --variable host="http://localhost:31976" tests.hurl
+# 	HURL_VARIABLE_blocked=false npx hurl --test --variable host="http://localhost:31976" tests.hurl
 # or (from root of the repo)
-#   HURL_blocked=false npm run test:local data-workflow
+#   HURL_VARIABLE_blocked=false npm run test:local data-workflow
 
 # WARNING: The webhook URLs don't last forever.
 #          Without activity, they expire after one week!
@@ -11,7 +11,7 @@
 #          Thus, there are commented here.
 
 ############################################################################
-# Test v1/hiddentext-detect : Texte blanc sur fond blanc et taille du texte minuscule 
+# Test v1/hiddentext-detect : Texte blanc sur fond blanc et taille du texte minuscule
 POST {{host}}/v1/hiddentext-detect
 content-type: application/x-gzip
 # X-Webhook-Success: https://webhook.site/684dd427-5484-404a-b5a0-80e5b6726a1c

--- a/services/terms-extraction/README.md
+++ b/services/terms-extraction/README.md
@@ -1,4 +1,4 @@
-# ws-terms-extraction@1.9.7
+# ws-terms-extraction@1.9.8
 
 Extraction de termes
 

--- a/services/terms-extraction/package.json
+++ b/services/terms-extraction/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "ws-terms-extraction",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "Extraction de termes",
   "repository": {
     "type": "git",

--- a/services/terms-extraction/swagger.json
+++ b/services/terms-extraction/swagger.json
@@ -15,7 +15,7 @@
             "x-comment": "Will be automatically completed by the ezs server."
         },
         {
-            "url": "http://vptdmservices.intra.inist.fr:49382/",
+            "url": "http://vptdmservices.intra.inist.fr:49399/",
             "description": "Latest version for production",
             "x-profil": "Standard"
         }

--- a/services/terms-extraction/swagger.json
+++ b/services/terms-extraction/swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "terms-extraction - Extraction de termes",
         "summary": "Extraction de termes à partir de textes en anglais ou en français.",
-        "version": "1.9.7",
+        "version": "1.9.8",
         "termsOfService": "https://services.istex.fr/",
         "contact": {
             "name": "Inist-CNRS",

--- a/services/terms-extraction/tests.hurl
+++ b/services/terms-extraction/tests.hurl
@@ -214,36 +214,6 @@ content-type: application/json
 
 HTTP 200
 [{
-    "id": "https://en.wikipedia.org/wiki/Perseverance_(rover)",
-    "value": [
-        {
-            "term": "perseverance",
-            "frequency": 6,
-            "specificity": 1
-        },
-        {
-            "term": "martian surface",
-            "frequency": 2,
-            "specificity": 0.7063
-        },
-        {
-            "term": "martian atmosphere",
-            "frequency": 2,
-            "specificity": 0.7063
-        },
-        {
-            "term": "crater jezero",
-            "frequency": 1,
-            "specificity": 0.3532
-        },
-        {
-            "term": "jet propulsion laboratory",
-            "frequency": 1,
-            "specificity": 0.3532
-        }
-    ]
-},
-{
     "id": "https://en.wikipedia.org/wiki/Text_mining",
     "value": [
         {
@@ -270,6 +240,36 @@ HTTP 200
             "term": "text data",
             "frequency": 1,
             "specificity": 0.25
+        }
+    ]
+},
+{
+    "id": "https://en.wikipedia.org/wiki/Perseverance_(rover)",
+    "value": [
+        {
+            "term": "perseverance",
+            "frequency": 6,
+            "specificity": 1
+        },
+        {
+            "term": "martian surface",
+            "frequency": 2,
+            "specificity": 0.7063
+        },
+        {
+            "term": "martian atmosphere",
+            "frequency": 2,
+            "specificity": 0.7063
+        },
+        {
+            "term": "crater jezero",
+            "frequency": 1,
+            "specificity": 0.3532
+        },
+        {
+            "term": "jet propulsion laboratory",
+            "frequency": 1,
+            "specificity": 0.3532
         }
     ]
 }]
@@ -739,4 +739,3 @@ HTTP 200
         "Donec luctus magna vitae mi malesuada, eget tristique turpis mattis."
     ]
 }]
-

--- a/services/terms-extraction/tests.hurl
+++ b/services/terms-extraction/tests.hurl
@@ -73,96 +73,59 @@ content-type: application/json
 ]
 
 HTTP 200
-[{
-    "id": "https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)",
-    "value": [
-        {
-            "term": "astromobile",
-            "frequency": 6,
-            "specificity": 1
-        },
-        {
-            "term": "sol martien",
-            "frequency": 3,
-            "specificity": 0.5
-        },
-        {
-            "term": "mission spatiale",
-            "frequency": 1,
-            "specificity": 0.1667
-        },
-        {
-            "term": "planète mars",
-            "frequency": 1,
-            "specificity": 0.1667
-        },
-        {
-            "term": "jpl établissement",
-            "frequency": 1,
-            "specificity": 0.1667
-        }
-    ]
-},
-{
-    "id": "https://fr.wikipedia.org/wiki/Mars_Exploration_Rover",
-    "value": [
-        {
-            "term": "deux robots",
-            "frequency": 2,
-            "specificity": 1
-        },
-        {
-            "term": "panneaux solaires",
-            "frequency": 2,
-            "specificity": 1
-        },
-        {
-            "term": "mars exploration rover mer",
-            "frequency": 1,
-            "specificity": 0.5
-        },
-        {
-            "term": "mission double",
-            "frequency": 1,
-            "specificity": 0.5
-        },
-        {
-            "term": "deux robots mobiles",
-            "frequency": 1,
-            "specificity": 0.5
-        }
-    ]
-},
-{
-    "id": "EGC2022",
-    "value": [
-        {
-            "term": "service tdm",
-            "frequency": 1,
-            "specificity": 0.5
-        },
-        {
-            "term": "web services",
-            "frequency": 1,
-            "specificity": 0.5
-        },
-        {
-            "term": "information scientifique",
-            "frequency": 1,
-            "specificity": 0.5
-        },
-        {
-            "term": "outil libre",
-            "frequency": 1,
-            "specificity": 0.5
-        },
-        {
-            "term": "informations présentes",
-            "frequency": 1,
-            "specificity": 0.5
-        }
-    ]
-}]
+[Asserts]
+jsonpath "$[*].id" contains "https://fr.wikipedia.org/wiki/Mars_Exploration_Rover"
+jsonpath "$[*].id" contains "EGC2022"
+jsonpath "$[*].id" contains "https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)"
+
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[*].term" contains "deux robots"
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[*].term" contains "panneaux solaires"
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[*].term" contains "mars exploration rover mer"
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[*].term" contains "mission double"
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[*].term" contains "deux robots mobiles"
+
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[?(@.term == 'deux robots')].frequency" == 2
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[?(@.term == 'deux robots')].specificity" == 1
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[?(@.term == 'panneaux solaires')].frequency" == 2
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[?(@.term == 'panneaux solaires')].specificity" == 1
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[?(@.term == 'mars exploration rover mer')].frequency" == 1
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[?(@.term == 'mars exploration rover mer')].specificity" == 0.5
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[?(@.term == 'mission double')].frequency" == 1
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[?(@.term == 'mission double')].specificity" == 0.5
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[?(@.term == 'deux robots mobiles')].frequency" == 1
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_Exploration_Rover')].value[?(@.term == 'deux robots mobiles')].specificity" == 0.5
+
+jsonpath "$[?(@.id == 'EGC2022')].value[*].term" contains "service tdm"
+jsonpath "$[?(@.id == 'EGC2022')].value[*].term" contains "web services"
+jsonpath "$[?(@.id == 'EGC2022')].value[*].term" contains "information scientifique"
+jsonpath "$[?(@.id == 'EGC2022')].value[*].term" contains "outil libre"
+jsonpath "$[?(@.id == 'EGC2022')].value[*].term" contains "informations présentes"
+jsonpath "$[?(@.id == 'EGC2022')].value[?(@.term == 'service tdm')].frequency" == 1
+jsonpath "$[?(@.id == 'EGC2022')].value[?(@.term == 'service tdm')].specificity" == 0.5
+jsonpath "$[?(@.id == 'EGC2022')].value[?(@.term == 'web services')].frequency" == 1
+jsonpath "$[?(@.id == 'EGC2022')].value[?(@.term == 'web services')].specificity" == 0.5
+jsonpath "$[?(@.id == 'EGC2022')].value[?(@.term == 'information scientifique')].frequency" == 1
+jsonpath "$[?(@.id == 'EGC2022')].value[?(@.term == 'information scientifique')].specificity" == 0.5
+jsonpath "$[?(@.id == 'EGC2022')].value[?(@.term == 'outil libre')].frequency" == 1
+jsonpath "$[?(@.id == 'EGC2022')].value[?(@.term == 'outil libre')].specificity" == 0.5
+jsonpath "$[?(@.id == 'EGC2022')].value[?(@.term == 'informations présentes')].frequency" == 1
+jsonpath "$[?(@.id == 'EGC2022')].value[?(@.term == 'informations présentes')].specificity" == 0.5
+
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[*].term" contains "astromobile"
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[*].term" contains "sol martien"
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[*].term" contains "mission spatiale"
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[*].term" contains "planète mars"
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[*].term" contains "jpl établissement"
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[?(@.term == 'astromobile')].frequency" == 6
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[?(@.term == 'astromobile')].specificity" == 1
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[?(@.term == 'sol martien')].frequency" == 3
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[?(@.term == 'sol martien')].specificity" == 0.5
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[?(@.term == 'mission spatiale')].frequency" == 1
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[?(@.term == 'mission spatiale')].specificity" == 0.1667
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[?(@.term == 'planète mars')].frequency" == 1
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[?(@.term == 'planète mars')].specificity" == 0.1667
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[?(@.term == 'jpl établissement')].frequency" == 1
+jsonpath "$[?(@.id == 'https://fr.wikipedia.org/wiki/Mars_2020_(mission_spatiale)')].value[?(@.term == 'jpl établissement')].specificity" == 0.1667
 
 POST {{host}}/v1/teeft/en?indent=true
 content-type: application/json
@@ -213,66 +176,28 @@ content-type: application/json
 ]
 
 HTTP 200
-[{
-    "id": "https://en.wikipedia.org/wiki/Text_mining",
-    "value": [
-        {
-            "term": "analytics",
-            "frequency": 4,
-            "specificity": 1
-        },
-        {
-            "term": "text analytics",
-            "frequency": 2,
-            "specificity": 0.5
-        },
-        {
-            "term": "high-quality information",
-            "frequency": 2,
-            "specificity": 0.5
-        },
-        {
-            "term": "natural language",
-            "frequency": 2,
-            "specificity": 0.5
-        },
-        {
-            "term": "text data",
-            "frequency": 1,
-            "specificity": 0.25
-        }
-    ]
-},
-{
-    "id": "https://en.wikipedia.org/wiki/Perseverance_(rover)",
-    "value": [
-        {
-            "term": "perseverance",
-            "frequency": 6,
-            "specificity": 1
-        },
-        {
-            "term": "martian surface",
-            "frequency": 2,
-            "specificity": 0.7063
-        },
-        {
-            "term": "martian atmosphere",
-            "frequency": 2,
-            "specificity": 0.7063
-        },
-        {
-            "term": "crater jezero",
-            "frequency": 1,
-            "specificity": 0.3532
-        },
-        {
-            "term": "jet propulsion laboratory",
-            "frequency": 1,
-            "specificity": 0.3532
-        }
-    ]
-}]
+[Asserts]
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Perseverance_(rover)')].value[?(@.term == 'perseverance')].frequency" == 6
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Perseverance_(rover)')].value[?(@.term == 'perseverance')].specificity" == 1
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Perseverance_(rover)')].value[?(@.term == 'martian surface')].frequency" == 2
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Perseverance_(rover)')].value[?(@.term == 'martian surface')].specificity" == 0.7063
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Perseverance_(rover)')].value[?(@.term == 'martian atmosphere')].frequency" == 2
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Perseverance_(rover)')].value[?(@.term == 'martian atmosphere')].specificity" == 0.7063
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Perseverance_(rover)')].value[?(@.term == 'crater jezero')].frequency" == 1
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Perseverance_(rover)')].value[?(@.term == 'crater jezero')].specificity" == 0.3532
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Perseverance_(rover)')].value[?(@.term == 'jet propulsion laboratory')].frequency" == 1
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Perseverance_(rover)')].value[?(@.term == 'jet propulsion laboratory')].specificity" == 0.3532
+
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Text_mining')].value[?(@.term == 'analytics')].frequency" == 4
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Text_mining')].value[?(@.term == 'analytics')].specificity" == 1
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Text_mining')].value[?(@.term == 'text analytics')].frequency" == 2
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Text_mining')].value[?(@.term == 'text analytics')].specificity" == 0.5
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Text_mining')].value[?(@.term == 'high-quality information')].frequency" == 2
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Text_mining')].value[?(@.term == 'high-quality information')].specificity" == 0.5
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Text_mining')].value[?(@.term == 'natural language')].frequency" == 2
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Text_mining')].value[?(@.term == 'natural language')].specificity" == 0.5
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Text_mining')].value[?(@.term == 'text data')].frequency" == 1
+jsonpath "$[?(@.id == 'https://en.wikipedia.org/wiki/Text_mining')].value[?(@.term == 'text data')].specificity" == 0.25
 
 POST {{host}}/v1/teeft/with-numbers/en?indent=true
 content-type: application/json

--- a/services/terms-extraction/v2/teeft/en.cfg
+++ b/services/terms-extraction/v2/teeft/en.cfg
@@ -1,0 +1,45 @@
+[use]
+plugin = @ezs/teeft
+
+[replace]
+path = content
+value = get('value')
+
+path = path
+value = get('id', 'n/a')
+
+[TeeftToLowerCase]
+path = content
+
+[TeeftSentenceTokenize]
+[TeeftTokenize]
+
+[TeeftNaturalTag]
+lang = en
+
+[TeeftExtractTerms]
+lang = en
+
+[TeeftFilterTags]
+lang = en
+
+[TeeftRemoveNumbers]
+[TeeftRemoveShortTerms]
+[TeeftRemoveLongTerms]
+[TeeftRemoveWeirdTerms]
+[TeeftStopWords]
+lang = en
+
+[TeeftSumUpFrequencies]
+[TeeftSpecificity]
+lang = en
+sort = true
+
+[TeeftFilterMonoFreq]
+
+[replace]
+path = id
+value = get('path')
+
+path = value
+value = get('terms').slice(0, env("nb", 5)).map(t => ({term: t.term, frequency: t.frequency, specificity: Number(t.specificity.toFixed(4))}))

--- a/services/terms-extraction/v2/teeft/en.ini
+++ b/services/terms-extraction/v2/teeft/en.ini
@@ -62,53 +62,14 @@ post.responses.default.content.application/json.example.1.value.4.specificity = 
 
 [use]
 plugin = @ezs/basics
-plugin = @ezs/teeft
 
 [JSONParse]
 separator = *
 
-[replace]
-path = content
-value = get('value')
-
-path = path
-value = get('id', 'n/a')
-
-[TeeftToLowerCase]
-path = content
-
-[TeeftSentenceTokenize]
-[TeeftTokenize]
-
-[TeeftNaturalTag]
-lang = en
-
-[TeeftExtractTerms]
-lang = en
-
-[TeeftFilterTags]
-lang = en
-
-[TeeftRemoveNumbers]
-[TeeftRemoveShortTerms]
-[TeeftRemoveLongTerms]
-[TeeftRemoveWeirdTerms]
-[TeeftStopWords]
-lang = en
-
-[TeeftSumUpFrequencies]
-[TeeftSpecificity]
-lang = en
-sort = true
-
-[TeeftFilterMonoFreq]
-
-[replace]
-path = id
-value = get('path')
-
-path = value
-value = get('terms').slice(0, env("nb", 5)).map(t => ({term: t.term, frequency: t.frequency, specificity: Number(t.specificity.toFixed(4))}))
+[parallel]
+concurrency = 5
+[parallel/detach]
+file = ./v2/teeft/en.cfg
 
 [dump]
 indent = env('indent', false)

--- a/services/terms-extraction/v2/teeft/fr.cfg
+++ b/services/terms-extraction/v2/teeft/fr.cfg
@@ -1,0 +1,45 @@
+[use]
+plugin = @ezs/teeft
+
+[replace]
+path = content
+value = get('value')
+
+path = path
+value = get('id', 'n/a')
+
+[TeeftToLowerCase]
+path = content
+
+[TeeftSentenceTokenize]
+[TeeftTokenize]
+
+[TeeftNaturalTag]
+lang = fr
+
+[TeeftExtractTerms]
+lang = fr
+
+[TeeftFilterTags]
+lang = fr
+
+[TeeftRemoveNumbers]
+[TeeftRemoveShortTerms]
+[TeeftRemoveLongTerms]
+[TeeftRemoveWeirdTerms]
+[TeeftStopWords]
+lang = fr
+
+[TeeftSumUpFrequencies]
+[TeeftSpecificity]
+lang = fr
+sort = true
+
+[TeeftFilterMonoFreq]
+
+[replace]
+path = id
+value = get('path')
+
+path = value
+value = get('terms').slice(0, env("nb", 5)).map(t => ({term: t.term, frequency: t.frequency, specificity: Number(t.specificity.toFixed(4))}))

--- a/services/terms-extraction/v2/teeft/fr.ini
+++ b/services/terms-extraction/v2/teeft/fr.ini
@@ -80,53 +80,14 @@ post.responses.default.content.application/json.example.2.value.4.specificity = 
 
 [use]
 plugin = @ezs/basics
-plugin = @ezs/teeft
 
 [JSONParse]
 separator = *
 
-[replace]
-path = content
-value = get('value')
-
-path = path
-value = get('id', 'n/a')
-
-[TeeftToLowerCase]
-path = content
-
-[TeeftSentenceTokenize]
-[TeeftTokenize]
-
-[TeeftNaturalTag]
-lang = fr
-
-[TeeftExtractTerms]
-lang = fr
-
-[TeeftFilterTags]
-lang = fr
-
-[TeeftRemoveNumbers]
-[TeeftRemoveShortTerms]
-[TeeftRemoveLongTerms]
-[TeeftRemoveWeirdTerms]
-[TeeftStopWords]
-lang = fr
-
-[TeeftSumUpFrequencies]
-[TeeftSpecificity]
-lang = fr
-sort = true
-
-[TeeftFilterMonoFreq]
-
-[replace]
-path = id
-value = get('path')
-
-path = value
-value = get('terms').slice(0, env("nb", 5)).map(t => ({term: t.term, frequency: t.frequency, specificity: Number(t.specificity.toFixed(4))}))
+[parallel]
+concurrency = 5
+[parallel/detach]
+file = ./v2/teeft/fr.cfg
 
 [dump]
 indent = env('indent', false)


### PR DESCRIPTION
Le but de cette PR est d'améliorer la vitesse de Teeft.

**Mais** le fait de paralléliser les traitements a compliqué les tests (les objets n'arrivent pas toujours dans le même ordre).
Un bug de la version 5.0.1 de hurl empêchait l'écriture des tests.
Je passe donc à la version 8.0.4 (!) qui introduit au passage plusieurs changements:

- la variable `HURL_blocked` doit être renommée `HURL_VARIABLE_blocked`
- certains tests sont cassés (`data-termsuite`: une syntaxe à corriger: `JSONPath expression '$[0].retrieve-json' is not valid`)

- [x] utiliser `parallel` et `detach` pour teeft (v2)
- [x] modifier la version de `hurl` installée dans `.github/workflows/test-and-publish-on-tag.yml`
- [x] modifier la version de `hurl` installée dans `.github/workflows/test-on-branch.yml`
- [x] corriger la documentation (à propos de `HURL_blocked`)
- [x] modifier les tests qui ne passent plus dans `data-termsuite`