### PR TITLE
chore: Reduce `EZS_CONCURRENCY` to a maximum of 2.

### DIFF
--- a/bases/ezs-python-pytorch-server/config.json
+++ b/bases/ezs-python-pytorch-server/config.json
@@ -3,7 +3,7 @@
         "EZS_TITLE": "ezs-pytorch server",
         "EZS_DESCRIPTION": "Web services",
         "EZS_METRICS": true,
-        "EZS_CONCURRENCY": 4,
+        "EZS_CONCURRENCY": 2,
         "EZS_CONTINUE_DELAY": 60,
         "EZS_NSHARDS": 32,
         "EZS_CACHE": true,

--- a/bases/ezs-python-saxon-server/config.json
+++ b/bases/ezs-python-saxon-server/config.json
@@ -3,7 +3,7 @@
         "EZS_TITLE": "ezs-saxon server",
         "EZS_DESCRIPTION": "Web services",
         "EZS_METRICS": true,
-        "EZS_CONCURRENCY": 4,
+        "EZS_CONCURRENCY": 2,
         "EZS_CONTINUE_DELAY": 60,
         "EZS_NSHARDS": 32,
         "EZS_CACHE": true,

--- a/services/authors-tools/config.json
+++ b/services/authors-tools/config.json
@@ -3,7 +3,7 @@
         "EZS_TITLE": "Les web services qui se lancent sur le champ 'authors'",
         "EZS_DESCRIPTION": "Regroupe tous les web services qui traitent des auteurs (noms, affiliations...)",
         "EZS_METRICS": true,
-        "EZS_CONCURRENCY": 4,
+        "EZS_CONCURRENCY": 2,
         "EZS_CONTINUE_DELAY": 60,
         "EZS_NSHARDS": 32,
         "EZS_CACHE": true,

--- a/services/data-workflow/config.json
+++ b/services/data-workflow/config.json
@@ -3,7 +3,7 @@
         "EZS_TITLE": "Enchaînement asynchrone de traitements",
         "EZS_DESCRIPTION": "Les worflows permettent de traiter des fichiers corpus compressés en appelant des webservices d'enrichissement par document de manière asynchrone.",
         "EZS_METRICS": true,
-        "EZS_CONCURRENCY": 4,
+        "EZS_CONCURRENCY": 2,
         "EZS_PIPELINE_DELAY": 10800,
         "EZS_CONTINUE_DELAY": 60,
         "EZS_NSHARDS": 32,

--- a/services/domains-classifier/config.json
+++ b/services/domains-classifier/config.json
@@ -3,7 +3,7 @@
         "EZS_TITLE": "Classification en domaines scientifiques",
         "EZS_DESCRIPTION": "Utilise une succession arborescente de modèles de type Fasttext pour prédire un code de classement Pascal/Francis",
         "EZS_METRICS": true,
-        "EZS_CONCURRENCY": 4,
+        "EZS_CONCURRENCY": 2,
         "EZS_CONTINUE_DELAY": 60,
         "EZS_NSHARDS": 32,
         "EZS_CACHE": true,

--- a/services/funder-ner/config.json
+++ b/services/funder-ner/config.json
@@ -3,7 +3,7 @@
         "EZS_TITLE": "Detection de financeurs",
         "EZS_DESCRIPTION": "Détecte des financeurs dans un article en anglais et renvoie la liste des financeurs repérés.",
         "EZS_METRICS": true,
-        "EZS_CONCURRENCY": 4,
+        "EZS_CONCURRENCY": 2,
         "EZS_CONTINUE_DELAY": 60,
         "EZS_NSHARDS": 32,
         "EZS_CACHE": true,

--- a/services/hal-classifier/config.json
+++ b/services/hal-classifier/config.json
@@ -3,7 +3,7 @@
         "EZS_TITLE": "Classification HAL",
         "EZS_DESCRIPTION": "Cette instance propose des outils de classification pour HAL",
         "EZS_METRICS": true,
-        "EZS_CONCURRENCY": 4,
+        "EZS_CONCURRENCY": 2,
         "EZS_CONTINUE_DELAY": 60,
         "EZS_NSHARDS": 32,
         "EZS_CACHE": true,

--- a/services/nlp-tools2/config.json
+++ b/services/nlp-tools2/config.json
@@ -3,7 +3,7 @@
         "EZS_TITLE": "Outils de NLP",
         "EZS_DESCRIPTION": "Outils de traitement de la langue",
         "EZS_METRICS": true,
-        "EZS_CONCURRENCY": 4,
+        "EZS_CONCURRENCY": 2,
         "EZS_CONTINUE_DELAY": 60,
         "EZS_NSHARDS": 32,
         "EZS_CACHE": true,

--- a/services/openalex-classification/config.json
+++ b/services/openalex-classification/config.json
@@ -3,7 +3,7 @@
         "EZS_TITLE": "Classification en domaines et fields selon la classification OpenAlex",
         "EZS_DESCRIPTION": "Le web service classe automatiquement des documents scientifiques en anglais dans le premier et le deuxième niveau de la classification OpenAlex",
         "EZS_METRICS": true,
-        "EZS_CONCURRENCY": 4,
+        "EZS_CONCURRENCY": 2,
         "EZS_CONTINUE_DELAY": 60,
         "EZS_NSHARDS": 32,
         "EZS_CACHE": true,

--- a/services/sciencemetrix-classification/config.json
+++ b/services/sciencemetrix-classification/config.json
@@ -3,7 +3,7 @@
         "EZS_TITLE": "Classification en domaines scientifiques Science-Metrix",
         "EZS_DESCRIPTION": "Le web service classe automatiquement des documents scientifiques en anglais dans le troisième niveau de la classification Science-Metrix",
         "EZS_METRICS": true,
-        "EZS_CONCURRENCY": 4,
+        "EZS_CONCURRENCY": 2,
         "EZS_CONTINUE_DELAY": 60,
         "EZS_NSHARDS": 32,
         "EZS_CACHE": true,


### PR DESCRIPTION
Pour éviter d'utiliser trop de ressources, il vaut mieux limiter `EZS_CONCURRENCY` à une valeur minimale (2 pour des services peu gourmand -en mémoire notamment-, et 1 pour les gourmands).

Sur les 54 services présents dans la branche principale de github, il y en a 34 qui utilisent la valeur 2.
Ça en laisse 18 à vérifier.